### PR TITLE
Expose utils from Icc-API dependency

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,3 +11,7 @@ export * from "./src/apis/PatientApi"
 export * from "./src/apis/UserApi"
 export * from "./src/apis/medTechApi"
 export * from "./src/filter"
+
+export * from "@icure/api/icc-x-api/utils/binary-utils"
+export * from "@icure/api/icc-x-api/utils/formatting-util"
+export * from "@icure/api/icc-x-api/utils/uuid-encoder"


### PR DESCRIPTION
Expose binary-utils, formatting-utils and uuid-encoder utils functions coming from icc-api dependency