### PR TITLE
Auto-share methods in user api will now share all data by default

### DIFF
--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -1,9 +1,9 @@
-import {Filter} from '../filter/Filter';
-import {PaginatedListUser} from '../models/PaginatedListUser';
-import {SharedDataType, User} from '../models/User';
-import {Connection} from "../models/Connection";
-import {Patient} from "../models/Patient";
-import {EmailMessageFactory, SMSMessageFactory} from "../utils/msgGtwMessageFactory";
+import { Filter } from '../filter/Filter'
+import { PaginatedListUser } from '../models/PaginatedListUser'
+import { SharedDataType, User } from '../models/User'
+import { Connection } from '../models/Connection'
+import { Patient } from '../models/Patient'
+import { EmailMessageFactory, SMSMessageFactory } from '../utils/msgGtwMessageFactory'
 
 /**
  * The UserApi interface provides methods to manage users.
@@ -23,7 +23,7 @@ export interface UserApi {
    * @param messageFactory a MessageFactory that generates an EmailMessage or a SMSMessage.
    * @param tokenDuration the validity duration of the short-lived token, in seconds (default 48 hours)
    */
-  createAndInviteUser(patient: Patient, messageFactory: SMSMessageFactory | EmailMessageFactory, tokenDuration?: number): Promise<User>;
+  createAndInviteUser(patient: Patient, messageFactory: SMSMessageFactory | EmailMessageFactory, tokenDuration?: number): Promise<User>
 
   /**
    * A user must have a login, an email or a mobilePhone defined, a user should be linked to either a Healthcare Professional, a Patient or a Device. When modifying an user, you must ensure that the rev obtained when getting or creating the user is present as the rev is used to guarantee that the user has not been modified by a third party.
@@ -100,17 +100,17 @@ export interface UserApi {
 
   /**
    * Add autoDelegations values to the user.
-   * @param type Type of AutoDelegation to add
    * @param dataOwnerIds Array of DataOwnerId to add
+   * @param type Type of AutoDelegation to add. Shares all data by default.
    * @return Updated user
    */
-  shareAllFutureDataWith(type: SharedDataType, dataOwnerIds: string[]): Promise<User>
+  shareAllFutureDataWith(dataOwnerIds: string[], type?: SharedDataType): Promise<User>
 
   /**
    * Removes autoDelegations values to the user.
-   * @param type Type of AutoDelegation to removes
    * @param dataOwnerIds Array of DataOwnerId to add
+   * @param type Type of AutoDelegation to removes. Shares all data by default.
    * @return Updated user
    */
-  stopSharingDataWith(type: SharedDataType, dataOwnerIds: string[]): Promise<User>
+  stopSharingDataWith(dataOwnerIds: string[], type?: SharedDataType): Promise<User>
 }

--- a/src/apis/impl/UserApiImpl.ts
+++ b/src/apis/impl/UserApiImpl.ts
@@ -208,7 +208,7 @@ export class UserApiImpl implements UserApi {
       })
   }
 
-  async shareAllFutureDataWith(type: SharedDataType, dataOwnerIds: string[]): Promise<User> {
+  async shareAllFutureDataWith(dataOwnerIds: string[], type?: SharedDataType): Promise<User> {
     const user = await this.userApi.getCurrentUser().catch((e) => {
       throw this.errorHandler.createErrorFromAny(e)
     })
@@ -220,7 +220,7 @@ export class UserApiImpl implements UserApi {
     }
 
     let newDataSharing
-    const currentAutoDelegationsForType = user.autoDelegations?.[type]
+    const currentAutoDelegationsForType = user.autoDelegations?.[type ?? 'all']
     if (currentAutoDelegationsForType) {
       const delegationsToAdd = dataOwnerIds.filter((item) => !currentAutoDelegationsForType.includes(item))
       if (delegationsToAdd.length > 0) {
@@ -235,7 +235,7 @@ export class UserApiImpl implements UserApi {
         ...Object.entries(user.autoDelegations ?? {}).reduce((accumulator, [key, values]) => {
           return { ...accumulator, [key]: [...values] }
         }, {}),
-        [type]: dataOwnerIds,
+        [type ?? 'all']: dataOwnerIds,
       }
     }
 
@@ -255,7 +255,7 @@ export class UserApiImpl implements UserApi {
     throw this.errorHandler.createErrorWithMessage("Couldn't add data sharing to user")
   }
 
-  async stopSharingDataWith(type: SharedDataType, dataOwnerIds: string[]): Promise<User> {
+  async stopSharingDataWith(dataOwnerIds: string[], type?: SharedDataType): Promise<User> {
     const user = await this.userApi.getCurrentUser().catch((e) => {
       throw this.errorHandler.createErrorFromAny(e)
     })
@@ -266,7 +266,7 @@ export class UserApiImpl implements UserApi {
       )
     }
 
-    const delegationsToRemove = user.autoDelegations?.[type]?.filter((item) => dataOwnerIds.indexOf(item) >= 0)
+    const delegationsToRemove = user.autoDelegations?.[type ?? 'all']?.filter((item) => dataOwnerIds.indexOf(item) >= 0)
 
     if (delegationsToRemove === undefined || delegationsToRemove.length === 0) {
       return UserMapper.toUser(user)!!

--- a/test/apis/user-api.ts
+++ b/test/apis/user-api.ts
@@ -1,50 +1,52 @@
-  import {getEnvVariables, setLocalStorage, TestUtils} from "../test-utils";
-import {v4 as uuid} from 'uuid'
-import {assert} from "chai"
+import { getEnvVariables, setLocalStorage, TestUtils } from '../test-utils'
+import { v4 as uuid } from 'uuid'
+import { assert } from 'chai'
 import 'isomorphic-fetch'
 
 setLocalStorage(fetch)
 
-const {iCureUrl: iCureUrl, msgGtwUrl: msgGtwUrl, authProcessHcpId: authProcessHcpId, specId: specId} = getEnvVariables()
+const { iCureUrl: iCureUrl, msgGtwUrl: msgGtwUrl, authProcessHcpId: authProcessHcpId, specId: specId } = getEnvVariables()
 
 describe('User API', () => {
   it('If sharedDataType already shared with ownerIds : 200 ok, return user (no treatment needed)', async () => {
-    const patAuthProcessId = process.env.ICURE_TS_TEST_PAT_AUTH_PROCESS_ID ?? "6a355458dbfa392cb5624403190c39e5";
+    const patAuthProcessId = process.env.ICURE_TS_TEST_PAT_AUTH_PROCESS_ID ?? '6a355458dbfa392cb5624403190c39e5'
     const delegation = uuid()
 
-    const {
-      api
-    } = await TestUtils.signUpUserUsingEmail(iCureUrl, msgGtwUrl, specId, patAuthProcessId, authProcessHcpId);
+    const { api } = await TestUtils.signUpUserUsingEmail(iCureUrl, msgGtwUrl, specId, patAuthProcessId, authProcessHcpId)
 
     // When a user shares data with the provided dataOwner, the user is returned successfully, with additional data sharing entries only and no duplicates
-    const userUpdatedWithUpdatedDelegationsOnMedicalInformation = await api.userApi.shareAllFutureDataWith('medicalInformation', [delegation])
+    const userUpdatedWithUpdatedDelegationsOnMedicalInformation = await api.userApi.shareAllFutureDataWith([delegation], 'medicalInformation')
     assert(userUpdatedWithUpdatedDelegationsOnMedicalInformation.sharingDataWith.medicalInformation.has(delegation))
 
     // When a user already shares data with the provided dataOwner, the user is returned successfully, without any additional request to iCure
-    const userUpdatedWithUpdatedDelegationsOnMedicalInformationButNoChanges = await api.userApi.shareAllFutureDataWith('medicalInformation', [delegation])
+    const userUpdatedWithUpdatedDelegationsOnMedicalInformationButNoChanges = await api.userApi.shareAllFutureDataWith(
+      [delegation],
+      'medicalInformation'
+    )
 
     assert(userUpdatedWithUpdatedDelegationsOnMedicalInformationButNoChanges.sharingDataWith.medicalInformation.has(delegation))
-    assert(JSON.stringify(userUpdatedWithUpdatedDelegationsOnMedicalInformation) === JSON.stringify(userUpdatedWithUpdatedDelegationsOnMedicalInformationButNoChanges))
+    assert(
+      JSON.stringify(userUpdatedWithUpdatedDelegationsOnMedicalInformation) ===
+        JSON.stringify(userUpdatedWithUpdatedDelegationsOnMedicalInformationButNoChanges)
+    )
   })
 
   it('A user should be able to share data with another dataOwner, and stop sharing data with him later', async () => {
-    const patAuthProcessId = process.env.ICURE_TS_TEST_PAT_AUTH_PROCESS_ID ?? "6a355458dbfa392cb5624403190c39e5";
+    const patAuthProcessId = process.env.ICURE_TS_TEST_PAT_AUTH_PROCESS_ID ?? '6a355458dbfa392cb5624403190c39e5'
     const delegation = uuid()
 
-  const {
-      api
-    } = await TestUtils.signUpUserUsingEmail(iCureUrl, msgGtwUrl, specId, patAuthProcessId, authProcessHcpId);
+    const { api } = await TestUtils.signUpUserUsingEmail(iCureUrl, msgGtwUrl, specId, patAuthProcessId, authProcessHcpId)
 
     // When a user shares data with the provided dataOwner, the user is returned successfully, with additional data sharing entries only on the right type
-    const userUpdatedWithUpdatedDelegationsOnAll = await api.userApi.shareAllFutureDataWith('all', [delegation])
+    const userUpdatedWithUpdatedDelegationsOnAll = await api.userApi.shareAllFutureDataWith([delegation], 'all')
 
     assert(userUpdatedWithUpdatedDelegationsOnAll.sharingDataWith.all.has(delegation))
     assert(!userUpdatedWithUpdatedDelegationsOnAll.sharingDataWith?.medicalInformation?.has(delegation))
 
     // When a user want to stop to share data with the provided dataOwner, the user is returned successfully, with removed data sharing entries only on provided type
-    const userUpdatedWithRemovedDelegationsOnMedicalInformation = await api.userApi.stopSharingDataWith('medicalInformation', [delegation])
+    const userUpdatedWithRemovedDelegationsOnMedicalInformation = await api.userApi.stopSharingDataWith([delegation], 'medicalInformation')
 
     assert(userUpdatedWithRemovedDelegationsOnMedicalInformation.sharingDataWith.all.has(delegation))
     assert(!userUpdatedWithRemovedDelegationsOnMedicalInformation.sharingDataWith?.medicalInformation?.has(delegation))
-  });
+  })
 })


### PR DESCRIPTION
Of the `SharedDataType`  that appear in the medtech sdk only `all`, `medicalInformation` and `financialInformation` are actually used in the standard typescript sdk, and `financialInformation` is not even relevant for the medtech sdk, since there are no invoices.
This PR introduces `all` as a default parameter to the `shareAllFutureDataWith` and `stopSharingDataWith` methods, to simplify the API use (and documentation).
Note: this breaks compatibility since the order of the parameters `type` and `dataOwnerIds` is now inverted.