### PR TITLE
Fixed Union and Intersection filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ws": "^8.5.0"
   },
   "devDependencies": {
-    "@icure/test-setup": "^0.0.33",
+    "@icure/test-setup": "^0.0.35",
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/isomorphic-fetch": "^0.0.36",

--- a/src/apis/impl/CodingApiImpl.ts
+++ b/src/apis/impl/CodingApiImpl.ts
@@ -41,7 +41,7 @@ export class CodingApiImpl implements CodingApi {
     }
 
     const codesToCreate = codingsToCreate.map((d) => CodingMapper.toCode(d))
-    const codesToUpdate = codingsToCreate.map((d) => CodingMapper.toCode(d))
+    const codesToUpdate = codingsToUpdate.map((d) => CodingMapper.toCode(d))
 
     const createdCodes = await Promise.all(
       codesToCreate.map((c) =>

--- a/src/filter/filterDsl.ts
+++ b/src/filter/filterDsl.ts
@@ -79,18 +79,23 @@ export class UserFilter implements FilterBuilder<User> {
   async build(): Promise<Filter<User>> {
     const filters = [
       this._byIds && ({ ids: this._byIds, $type: 'UserByIdsFilter' } as UserByIdsFilter),
-      this._patientId && ({ patientId: this._patientId, $type: 'UsersByPatientIdFilter' } as UsersByPatientIdFilter),
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<User>),
-      this._intersection &&
-        ({ filters: await Promise.all(this._intersection.map((f) => f.build())), $type: 'IntersectionFilter' } as IntersectionFilter<User>),
+      this._patientId && ({ patientId: this._patientId, $type: 'UsersByPatientIdFilter' } as UsersByPatientIdFilter)
     ].filter((x) => !!x) as Filter<User>[]
 
-    if (!filters.length) {
-      return { $type: 'AllUsersFilter' } as AllUsersFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<User>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<User>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<User>
+      return { $type: 'AllUsersFilter' } as AllUsersFilter
     }
   }
 }
@@ -204,25 +209,23 @@ export class PatientFilter implements FilterBuilder<Patient> {
           healthcarePartyId: dataOwnerId,
           searchString: this._containsFuzzy,
           $type: 'PatientByHealthcarePartyNameContainsFuzzyFilter',
-        } as PatientByHealthcarePartyNameContainsFuzzyFilter),
-      this._union &&
-        ({
-          filters: await Promise.all(this._union.map((f) => f.build())),
-          $type: 'UnionFilter',
-        } as UnionFilter<Patient>),
-      this._intersection &&
-        ({
-          filters: await Promise.all(this._intersection.map((f) => f.build())),
-          $type: 'IntersectionFilter',
-        } as IntersectionFilter<Patient>),
+        } as PatientByHealthcarePartyNameContainsFuzzyFilter)
     ].filter((x) => !!x) as Filter<Patient>[]
 
-    if (!filters.length) {
-      return { healthcarePartyId: dataOwnerId, $type: 'PatientByHealthcarePartyFilter' } as PatientByHealthcarePartyFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<Patient>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<Patient>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<Patient>
+      return { healthcarePartyId: dataOwnerId, $type: 'PatientByHealthcarePartyFilter' } as PatientByHealthcarePartyFilter
     }
   }
 }
@@ -262,21 +265,23 @@ export class HealthcareProfessionalFilter implements FilterBuilder<HealthcarePro
   async build(): Promise<Filter<HealthcareProfessional>> {
     const filters = [
       this._byIds && ({ ids: this._byIds, $type: 'HealthcareProfessionalByIdsFilter' } as HealthcareProfessionalByIdsFilter),
-      this._byLabelCodeFilter,
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<HealthcareProfessional>),
-      this._intersection &&
-        ({
-          filters: await Promise.all(this._intersection.map((f) => f.build())),
-          $type: 'IntersectionFilter',
-        } as IntersectionFilter<HealthcareProfessional>),
+      this._byLabelCodeFilter
     ].filter((x) => !!x) as Filter<HealthcareProfessional>[]
 
-    if (!filters.length) {
-      return { $type: 'AllHealthcareProfessionalsFilter' } as AllHealthcareProfessionalsFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<HealthcareProfessional>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<HealthcareProfessional>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<HealthcareProfessional>
+      return { $type: 'AllHealthcareProfessionalsFilter' } as AllHealthcareProfessionalsFilter
     }
   }
 }
@@ -303,18 +308,23 @@ export class MedicalDeviceFilter implements FilterBuilder<MedicalDevice> {
 
   async build(): Promise<Filter<MedicalDevice>> {
     const filters = [
-      this._byIds && ({ ids: this._byIds, $type: 'MedicalDeviceByIdsFilter' } as MedicalDeviceByIdsFilter),
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<MedicalDevice>),
-      this._intersection &&
-        ({ filters: await Promise.all(this._intersection.map((f) => f.build())), $type: 'IntersectionFilter' } as IntersectionFilter<MedicalDevice>),
+      this._byIds && ({ ids: this._byIds, $type: 'MedicalDeviceByIdsFilter' } as MedicalDeviceByIdsFilter)
     ].filter((x) => !!x) as Filter<MedicalDevice>[]
 
-    if (!filters.length) {
-      return { $type: 'AllMedicalDevicesFilter' } as AllMedicalDevicesFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<MedicalDevice>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<MedicalDevice>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<MedicalDevice>
+      return { $type: 'AllMedicalDevicesFilter' } as AllMedicalDevicesFilter
     }
   }
 }
@@ -410,20 +420,22 @@ export class HealthcareElementFilter implements FilterBuilder<HealthcareElement>
           ).reduce((t, v) => t.concat(v[0]), [] as string[]),
           $type: 'HealthcareElementByHealthcarePartyPatientFilter',
         } as HealthcareElementByHealthcarePartyPatientFilter),
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<HealthcareElement>),
-      this._intersection &&
-        ({
-          filters: await Promise.all(this._intersection.map((f) => f.build())),
-          $type: 'IntersectionFilter',
-        } as IntersectionFilter<HealthcareElement>),
     ].filter((x) => !!x) as Filter<HealthcareElement>[]
 
-    if (!filters.length) {
-      return { healthcarePartyId: dataOwnerId, $type: 'HealthcareElementByHealthcarePartyFilter' } as HealthcareElementByHealthcarePartyFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<HealthcareElement>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<HealthcareElement>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<HealthcareElement>
+      return { healthcarePartyId: dataOwnerId, $type: 'HealthcareElementByHealthcarePartyFilter' } as HealthcareElementByHealthcarePartyFilter
     }
   }
 }
@@ -439,7 +451,7 @@ export class CodingFilter implements FilterBuilder<Coding> {
     return this
   }
 
-  byRegionTypeLabelLanguage(region?: string, type?: string, language?: string, label?: string): CodingFilter {
+  byRegionLanguageTypeLabel(region?: string, language?: string, type?: string, label?: string): CodingFilter {
     this._byRegionTypeLabelLanguageFilter = { region, type, language, label, $type: 'CodingByRegionTypeLabelFilter' } as CodingByRegionTypeLabelFilter
     return this
   }
@@ -457,18 +469,23 @@ export class CodingFilter implements FilterBuilder<Coding> {
   async build(): Promise<Filter<Coding>> {
     const filters = [
       this._byIds && ({ ids: this._byIds, $type: 'CodingByIdsFilter' } as CodingByIdsFilter),
-      this._byRegionTypeLabelLanguageFilter,
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<Coding>),
-      this._intersection &&
-        ({ filters: await Promise.all(this._intersection.map((f) => f.build())), $type: 'IntersectionFilter' } as IntersectionFilter<Coding>),
+      this._byRegionTypeLabelLanguageFilter
     ].filter((x) => !!x) as Filter<Coding>[]
 
-    if (!filters.length) {
-      return { $type: 'AllCodingsFilter' } as AllCodingsFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<Coding>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<Coding>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<Coding>
+      return { $type: 'AllCodingsFilter' } as AllCodingsFilter
     }
   }
 }
@@ -525,18 +542,23 @@ export class NotificationFilter implements FilterBuilder<Notification> {
           $type: 'NotificationsByHcPartyAndTypeFilter',
         } as NotificationsByHcPartyAndTypeFilter),
       this._fromDate &&
-        ({ healthcarePartyId: this._dataOwnerId, date: this._fromDate, $type: 'NotificationsAfterDateFilter' } as NotificationsAfterDateFilter),
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<Notification>),
-      this._intersection &&
-        ({ filters: await Promise.all(this._intersection.map((f) => f.build())), $type: 'IntersectionFilter' } as IntersectionFilter<Notification>),
+        ({ healthcarePartyId: this._dataOwnerId, date: this._fromDate, $type: 'NotificationsAfterDateFilter' } as NotificationsAfterDateFilter)
     ].filter((x) => !!x) as Filter<Notification>[]
 
-    if (!filters.length) {
-      return { healthcarePartyId: this._dataOwnerId, date: 0, $type: 'NotificationsAfterDateFilter' } as NotificationsAfterDateFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<Notification>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<Notification>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters } as IntersectionFilter<Notification>
+      return { healthcarePartyId: this._dataOwnerId, date: 0, $type: 'NotificationsAfterDateFilter' } as NotificationsAfterDateFilter
     }
   }
 }
@@ -655,19 +677,23 @@ export class DataSampleFilter implements FilterBuilder<DataSample> {
             )
           ).reduce((patientSecretForeignKeys, extractedKeys) => patientSecretForeignKeys.concat(extractedKeys[0]), [] as string[]),
           $type: 'DataSampleByHealthcarePartyPatientFilter',
-        } as DataSampleByHealthcarePartyPatientFilter),
-
-      this._union && ({ filters: await Promise.all(this._union.map((f) => f.build())), $type: 'UnionFilter' } as UnionFilter<DataSample>),
-      this._intersection &&
-        ({ filters: await Promise.all(this._intersection.map((f) => f.build())), $type: 'IntersectionFilter' } as IntersectionFilter<DataSample>),
+        } as DataSampleByHealthcarePartyPatientFilter)
     ].filter((x) => !!x) as Filter<DataSample>[]
 
-    if (!filters.length) {
-      return { hcpId: doId, $type: 'DataSampleByHealthcarePartyFilter' } as DataSampleByHealthcarePartyFilter
-    } else if (filters.length == 1) {
+    if (!!this._union) {
+      return {
+        filters: await Promise.all(this._union.map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'UnionFilter',
+      } as UnionFilter<DataSample>
+    } else if (filters.length > 1 || !!this._intersection) {
+      return {
+        filters: await Promise.all((this._intersection ?? []).map((f) => f.build())).then( (fs) => fs.concat(filters)),
+        $type: 'IntersectionFilter',
+      } as IntersectionFilter<DataSample>
+    } else if (filters.length === 1) {
       return filters[0]
     } else {
-      return { filters: filters, $type: 'IntersectionFilter' } as IntersectionFilter<DataSample>
+      return { hcpId: doId, $type: 'DataSampleByHealthcarePartyFilter' } as DataSampleByHealthcarePartyFilter
     }
   }
 }

--- a/src/mappers/codeCoding.ts
+++ b/src/mappers/codeCoding.ts
@@ -12,6 +12,7 @@ export namespace CodingMapper {
       type: dto.type,
       code: dto.code,
       version: dto.version,
+      regions: dto.regions,
       description: dto.label,
     });
 
@@ -24,6 +25,7 @@ export namespace CodingMapper {
       type: obj.type,
       code: obj.code,
       version: obj.version,
+      regions: obj.regions,
       label: obj.description
     });
 }

--- a/src/mappers/filter.ts
+++ b/src/mappers/filter.ts
@@ -168,7 +168,7 @@ export namespace FilterMapper {
     if (filter['$type'] === 'CodingByIdsFilter') {
       return toCodeByIdsFilterDto(filter as CodingByIdsFilter);
     }
-    if (filter['$type'] === 'CodingByRegionTypeLabelLanguageFilter') {
+    if (filter['$type'] === 'CodingByRegionTypeLabelFilter') {
       return toCodeByRegionTypeLabelLanguageFilterDto(filter as CodingByRegionTypeLabelFilter);
     }
     throw Error(`No mapper for ${filter['$type']}`);

--- a/src/models/Coding.ts
+++ b/src/models/Coding.ts
@@ -30,6 +30,7 @@ constructor(json: ICoding) {
     * Must be lexicographically searchable
     */
     'version'?: string;
+    'regions'?: Array<string>;
     /**
     * Description (ex: {en: Rheumatic Aortic Stenosis, fr: Sténose rhumatoïde de l'Aorte})
     */
@@ -51,6 +52,7 @@ interface ICoding {
   'type'?: string;
   'code'?: string;
   'version'?: string;
+  'regions'?: Array<string>;
   'description'?: { [key: string]: string; };
   'qualifiedLinks'?: { [key: string]: Array<string>; };
   'searchTerms'?: { [key: string]: Set<string>; };

--- a/test/apis/authentication-api.ts
+++ b/test/apis/authentication-api.ts
@@ -174,7 +174,7 @@ describe('Authentication API', () => {
     assert(currentUser)
     assert(currentUser.patientId != null)
 
-    const keyPair = await api.initUserCrypto()
+    await api.initUserCrypto()
     try {
       await api.initUserCrypto()
     } catch (e) {

--- a/test/filter/coding-filters-tests.ts
+++ b/test/filter/coding-filters-tests.ts
@@ -1,0 +1,176 @@
+import 'isomorphic-fetch';
+import {MedTechApi} from "../../src/apis/MedTechApi";
+import {User} from "../../src/models/User";
+import {
+  getEnvironmentInitializer,
+  getEnvVariables,
+  hcp1Username,
+  setLocalStorage,
+  TestUtils,
+  TestVars
+} from "../test-utils";
+import {CodingFilter} from "../../src/filter";
+import {expect} from "chai";
+import {Coding} from "../../src/models/Coding";
+import { v4 as uuid } from 'uuid'
+
+setLocalStorage(fetch);
+
+let env: TestVars;
+let hcp1Api: MedTechApi
+let hcp1User: User
+
+let code1: Coding
+let code2: Coding
+let code3: Coding
+
+describe("Coding Filters Test", function () {
+
+  before(async function () {
+    this.timeout(60000)
+    const initializer = await getEnvironmentInitializer();
+    env = await initializer.execute(getEnvVariables());
+
+    const hcp1ApiAndUser = await TestUtils.createMedTechApiAndLoggedUserFor(
+      env.iCureUrl,
+      env.dataOwnerDetails[hcp1Username]);
+    hcp1Api = hcp1ApiAndUser.api;
+    hcp1User = hcp1ApiAndUser.user;
+
+    code1 = await hcp1Api.codingApi.createOrModifyCoding(
+      new Coding({
+        type: 'ICURE',
+        code: 'PARARIBULITIS',
+        version: uuid().substring(0,6),
+        regions: ["be"],
+        description: { 'fr': 'Pararibulitis' }
+      })
+    )
+
+    code2 = await hcp1Api.codingApi.createOrModifyCoding(
+      new Coding({
+        type: 'ICURE',
+        code: 'UNIVERSE THERMAL DEATH',
+        version: uuid().substring(0,6),
+        regions: ["ir", "gb"],
+        description: { 'en': 'That is bad' }
+      })
+    )
+
+    code3 = await hcp1Api.codingApi.createOrModifyCoding(
+      new Coding({
+        type: 'SNOMED',
+        code: 'HEADACHE',
+        version: uuid().substring(0,6),
+        regions: ["ir", "gb"],
+        description: { 'en': 'Ouch' }
+      })
+    )
+
+  });
+
+  it("If no parameter is specified, all the Codings are returned", async function () {
+    const codes = await hcp1Api.codingApi.filterCoding(await new CodingFilter().build())
+
+    expect(codes.rows.length).to.be.greaterThan(0)
+  })
+
+  it("Can filter Codings by ids", async function () {
+    const codes = await hcp1Api.codingApi.filterCoding(
+      await new CodingFilter()
+        .byIds([code1.id!, code2.id!])
+        .build()
+    )
+
+    expect(codes.rows.length).to.be.equal(2)
+    expect(codes.rows.map( (it) => it.id )).to.contain(code1.id)
+    expect(codes.rows.map( (it) => it.id )).to.contain(code2.id)
+  }).timeout(60000)
+
+  it("Can filter Codings by language", async function () {
+    const codes = await hcp1Api.codingApi.filterCoding(
+      await new CodingFilter()
+        .byRegionLanguageTypeLabel('be')
+        .build()
+    )
+
+    expect(codes.rows.length).to.be.greaterThan(0)
+    codes.rows.forEach( (code) => {
+      expect(code.regions ?? []).to.contain('be')
+    })
+  }).timeout(60000)
+
+  it("Can filter Codings by union filter", async function () {
+    const codeByIdFilter = new CodingFilter()
+      .byIds([code1.id!])
+
+    const filterByIdOrType = await new CodingFilter()
+      .byRegionLanguageTypeLabel('gb', 'en', 'SNOMED')
+      .union([codeByIdFilter])
+      .build()
+
+    const codes = await hcp1Api.codingApi.filterCoding(filterByIdOrType)
+
+    expect(codes.rows.length).to.be.greaterThan(0)
+    codes.rows.forEach( (code) => {
+      expect(code).to.satisfy( (c: Coding) => {
+        return c.id === code1.id! || (
+          (c.regions ?? []).includes('gb') &&
+          Object.keys(c.description ?? {}).includes('en') &&
+          c.type === 'SNOMED'
+        )
+      })
+    })
+  }).timeout(60000)
+
+  it("Can filter Codings by implicit intersection filter", async function () {
+    const codes = await hcp1Api.codingApi.filterCoding(
+      await new CodingFilter()
+        .byRegionLanguageTypeLabel('gb', 'en', 'SNOMED')
+        .byIds([code1.id!, code2.id!, code3.id!])
+        .build()
+    )
+    expect(codes.rows.length).to.be.equal(1)
+    codes.rows.forEach( (code) => {
+      expect(code.id).to.be.oneOf([code1.id!, code2.id!, code3.id!])
+      expect(code).to.satisfy( (c: Coding) => {
+        return (c.regions ?? []).includes('gb') &&
+          Object.keys(c.description ?? {}).includes('en') &&
+          c.type === 'SNOMED'
+      })
+    })
+  })
+
+  it("Can filter Codings by explicit intersection filter", async function () {
+    const codesByIdFilter = new CodingFilter().byIds([code1.id!, code2.id!, code3.id!])
+
+    const codes = await hcp1Api.codingApi.filterCoding(
+      await new CodingFilter()
+        .byRegionLanguageTypeLabel('gb', 'en', 'SNOMED')
+        .intersection([codesByIdFilter])
+        .build()
+    )
+    expect(codes.rows.length).to.be.equal(1)
+    codes.rows.forEach( (code) => {
+      expect(code.id).to.be.oneOf([code1.id!, code2.id!, code3.id!])
+      expect(code).to.satisfy( (c: Coding) => {
+        return (c.regions ?? []).includes('gb') &&
+          Object.keys(c.description ?? {}).includes('en') &&
+          c.type === 'SNOMED'
+      })
+    })
+  })
+
+  it("Intersection between disjoint sets return empty result", async function () {
+    const codesByIdFilter = new CodingFilter().byIds([code1.id!])
+
+    const codes = await hcp1Api.codingApi.filterCoding(
+      await new CodingFilter()
+        .byRegionLanguageTypeLabel('gb', 'en', 'SNOMED')
+        .intersection([codesByIdFilter])
+        .build()
+    )
+    expect(codes.rows.length).to.be.equal(0)
+  })
+
+});

--- a/test/filter/data-sample-filters-tests.ts
+++ b/test/filter/data-sample-filters-tests.ts
@@ -1,0 +1,268 @@
+import 'isomorphic-fetch';
+import {MedTechApi} from "../../src/apis/MedTechApi";
+import {User} from "../../src/models/User";
+import {
+  getEnvironmentInitializer,
+  getEnvVariables,
+  hcp1Username,
+  setLocalStorage,
+  TestUtils,
+  TestVars
+} from "../test-utils";
+import {DataSampleFilter} from "../../src/filter";
+import {expect} from "chai";
+import {DataSample} from "../../src/models/DataSample";
+import {CodingReference} from "../../src/models/CodingReference";
+import {Patient} from "../../src/models/Patient";
+import {HealthcareElement} from "../../src/models/HealthcareElement";
+
+setLocalStorage(fetch);
+
+let env: TestVars;
+let hcp1Api: MedTechApi
+let hcp1User: User
+
+let ds1: DataSample
+let ds2: DataSample
+let ds3: DataSample
+let he1: HealthcareElement
+
+let patient: Patient
+
+describe("Data Sample Filters Tests", function () {
+
+  before(async function () {
+    this.timeout(60000)
+    const initializer = await getEnvironmentInitializer();
+    env = await initializer.execute(getEnvVariables());
+
+    const hcp1ApiAndUser = await TestUtils.createMedTechApiAndLoggedUserFor(
+      env.iCureUrl,
+      env.dataOwnerDetails[hcp1Username]);
+    hcp1Api = hcp1ApiAndUser.api;
+    hcp1User = hcp1ApiAndUser.user;
+
+    patient = await hcp1Api.patientApi.createOrModifyPatient(
+      new Patient({
+        firstName: 'Dirk',
+        lastName: 'Gently'
+      })
+    )
+
+    ds1 = await hcp1Api.dataSampleApi.createOrModifyDataSampleFor(
+      patient.id!,
+      new DataSample({
+        codes: new Set([
+          new CodingReference({
+            id: 'SNOMEDCT|617|20020131',
+            type: 'SNOMEDCT',
+            code: '617',
+            version: '20020131',
+          }),
+        ]),
+        content: { en: { stringValue: 'Hello world' } }
+      })
+    )
+
+    he1 = await hcp1Api.healthcareElementApi.createOrModifyHealthcareElement(
+      new HealthcareElement({
+        description: 'The patient has been diagnosed Pararibulitis',
+        codes: new Set([
+          new CodingReference({
+            id: 'SNOMEDCT|617|20020131',
+            type: 'SNOMEDCT',
+            code: '617',
+            version: '20020131',
+          }),
+        ]),
+      }),
+      patient.id!
+    )
+
+    ds2 = await hcp1Api.dataSampleApi.createOrModifyDataSampleFor(
+      patient.id!,
+      new DataSample({
+        healthcareElementIds: new Set([he1.id!]),
+        codes: new Set([
+          new CodingReference({
+            id: 'SNOMEDCT|617|20020131',
+            type: 'SNOMEDCT',
+            code: '617',
+            version: '20020131',
+          }),
+        ]),
+        content: { en: { stringValue: 'Hello world' } }
+      })
+    )
+
+    ds3 = await hcp1Api.dataSampleApi.createOrModifyDataSampleFor(
+      patient.id!,
+      new DataSample({
+        labels: new Set([
+          new CodingReference({
+            id: 'SNOMEDCT|617|20020131',
+            type: 'SNOMEDCT',
+            code: '617',
+            version: '20020131',
+          }),
+        ]),
+        content: { en: { stringValue: 'Hello world' } }
+      })
+    )
+
+  });
+
+  it("If no parameter is specified, all the Data Samples for a HCP are returned", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+  })
+
+  it("Can filter Data Samples by ids", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byIds([ds1.id!, ds2.id!])
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.equal(2)
+    expect(samples.rows.map( (it) => it.id )).to.contain(ds1.id)
+    expect(samples.rows.map( (it) => it.id )).to.contain(ds1.id)
+  })
+
+  it("Can filter Data Samples by patient", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .forPatients(hcp1Api.cryptoApi, [patient])
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+  })
+
+  it("Can filter Data Samples by Healthcare Element id", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byHealthElementIds([he1.id!])
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.equal(1)
+    samples.rows.forEach( (sample) => {
+      expect(sample.healthcareElementIds).to.contain(he1.id)
+    })
+  })
+
+  it("Can filter Data Samples by labels", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byLabelCodeFilter(
+          'SNOMEDCT',
+          '617'
+        )
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+    samples.rows.forEach( (sample) => {
+      expect(Array.from(sample.labels).map( (it) => it.code)).to.contain('617')
+      expect(Array.from(sample.labels).map( (it) => it.type)).to.contain('SNOMEDCT')
+    })
+  }).timeout(60000)
+
+  it("Can filter Data Samples by codes", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byLabelCodeFilter(
+          undefined,
+          undefined,
+          'SNOMEDCT',
+          '617'
+        )
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+    samples.rows.forEach( (sample) => {
+      expect(Array.from(sample.codes).map( (it) => it.code)).to.contain('617')
+      expect(Array.from(sample.codes).map( (it) => it.type)).to.contain('SNOMEDCT')
+    })
+  }).timeout(60000)
+
+  it("Can filter Data Samples by union filter", async function () {
+    const byHEFilter = new DataSampleFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byHealthElementIds([he1.id!])
+
+    const filterByHeOrId = await new DataSampleFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byIds([ds1.id!])
+      .union([byHEFilter])
+      .build()
+
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(filterByHeOrId)
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+    samples.rows.forEach( (sample) => {
+      expect(sample).to.satisfy( (s: DataSample) => {
+        return s.id === ds1.id! || Array.from(s.healthcareElementIds ?? []).includes(he1.id!)
+      })
+    })
+  })
+
+  it("Can filter Data Samples by explicit intersection filter", async function () {
+    const filterByPatient = new DataSampleFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .forPatients(hcp1Api.cryptoApi, [patient])
+
+    const filterByPatientAndByHe = await new DataSampleFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byHealthElementIds([he1.id!])
+      .intersection([filterByPatient])
+      .build()
+
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(filterByPatientAndByHe)
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+    samples.rows.forEach( (sample) => {
+      expect(sample.healthcareElementIds).to.contain(he1.id)
+    })
+  })
+
+  it("Can filter Data Samples by implicit intersection filter", async function () {
+    const filterByPatientAndByHe = await new DataSampleFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byHealthElementIds([he1.id!])
+      .forPatients(hcp1Api.cryptoApi, [patient])
+      .build()
+
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(filterByPatientAndByHe)
+
+    expect(samples.rows.length).to.be.greaterThan(0)
+    samples.rows.forEach( (sample) => {
+      expect(sample.healthcareElementIds).to.contain(he1.id)
+    })
+  })
+
+  it("Intersection between disjoint sets return empty result", async function () {
+    const samples = await hcp1Api.dataSampleApi.filterDataSample(
+      await new DataSampleFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byHealthElementIds([he1.id!])
+        .byIds([ds1.id!])
+        .build()
+    )
+
+    expect(samples.rows.length).to.be.equal(0)
+  })
+
+});

--- a/test/filter/healthcare-element-filters-tests.ts
+++ b/test/filter/healthcare-element-filters-tests.ts
@@ -1,0 +1,243 @@
+import 'isomorphic-fetch';
+import {MedTechApi} from "../../src/apis/MedTechApi";
+import {User} from "../../src/models/User";
+import {
+  getEnvironmentInitializer,
+  getEnvVariables,
+  hcp1Username,
+  setLocalStorage,
+  TestUtils,
+  TestVars
+} from "../test-utils";
+import {HealthcareElementFilter} from "../../src/filter";
+import {expect} from "chai";
+import {HealthcareElement} from "../../src/models/HealthcareElement";
+import {CodingReference} from "../../src/models/CodingReference";
+import {Patient} from "../../src/models/Patient";
+
+setLocalStorage(fetch);
+
+let env: TestVars;
+let hcp1Api: MedTechApi
+let hcp1User: User
+
+let patient: Patient
+let he1: HealthcareElement
+let he2: HealthcareElement
+let he3: HealthcareElement
+
+describe("Healthcare Element Filters Test", function () {
+
+  before(async function () {
+    this.timeout(60000)
+    const initializer = await getEnvironmentInitializer();
+    env = await initializer.execute(getEnvVariables());
+
+    const hcp1ApiAndUser = await TestUtils.createMedTechApiAndLoggedUserFor(
+      env.iCureUrl,
+      env.dataOwnerDetails[hcp1Username]);
+    hcp1Api = hcp1ApiAndUser.api;
+    hcp1User = hcp1ApiAndUser.user;
+
+    patient = await hcp1Api.patientApi.createOrModifyPatient(
+      new Patient({
+        firstName: 'Dirk',
+        lastName: 'Gently'
+      })
+    )
+
+    he1 = await hcp1Api.healthcareElementApi.createOrModifyHealthcareElement(
+      new HealthcareElement({
+        description: 'The patient has been diagnosed Pararibulitis',
+        codes: new Set([
+          new CodingReference({
+            id: 'SNOMEDCT|617|20020131',
+            type: 'SNOMEDCT',
+            code: '617',
+            version: '20020131',
+          }),
+        ]),
+      }),
+      patient.id!
+    )
+
+    he2 = await hcp1Api.healthcareElementApi.createOrModifyHealthcareElement(
+      new HealthcareElement({
+        description: 'The patient has been diagnosed Pararibulitis',
+        tags: new Set([
+          new CodingReference({
+            id: 'SNOMEDCT|617|20020131',
+            type: 'SNOMEDCT',
+            code: '617',
+            version: '20020131',
+          }),
+        ]),
+      }),
+      patient.id!
+    )
+
+    he3 = await hcp1Api.healthcareElementApi.createOrModifyHealthcareElement(
+      new HealthcareElement({
+        description: 'The patient is allergic to Vogon poetry'
+      }),
+      patient.id!
+    )
+
+  });
+
+  it("If no parameter is specified, all healthcare Elements for the HCP are returned", async function () {
+    const filter = await new HealthcareElementFilter().forDataOwner(hcp1User.healthcarePartyId!).build()
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(filter)
+
+    expect(elements.rows.length).to.be.greaterThan(0)
+    elements.rows.forEach( (he) => {
+      expect(Object.keys(he.systemMetaData?.delegations ?? {})).to.contain(hcp1User.healthcarePartyId!)
+    })
+  })
+
+  it("Can filter Healthcare Elements by patient", async function () {
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(
+      await new HealthcareElementFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .forPatients(hcp1Api.cryptoApi, [patient])
+        .build()
+    )
+
+    expect(!!elements).to.eq(true)
+    expect(elements.rows.length).to.be.greaterThan(0)
+  }).timeout(60000)
+
+  it("Can filter Healthcare Elements by code", async function () {
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(
+      await new HealthcareElementFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byLabelCodeFilter(
+          'SNOMEDCT',
+          '617'
+        )
+        .build()
+    )
+
+    expect(!!elements).to.eq(true)
+    expect(elements.rows.length).to.be.greaterThan(0)
+    elements.rows.forEach( (he) => {
+      expect(Array.from(he.tags).map( (it) => it.code)).to.contain('617')
+      expect(Array.from(he.tags).map( (it) => it.type)).to.contain('SNOMEDCT')
+    })
+  }).timeout(60000)
+
+  it("Can filter Healthcare Elements by tag", async function () {
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(
+      await new HealthcareElementFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byLabelCodeFilter(
+          undefined,
+          undefined,
+          'SNOMEDCT',
+          '617'
+        )
+        .build()
+    )
+
+    expect(!!elements).to.eq(true)
+    expect(elements.rows.length).to.be.greaterThan(0)
+    elements.rows.forEach( (he) => {
+      expect(Array.from(he.codes).map( (it) => it.type)).to.contain('SNOMEDCT')
+      expect(Array.from(he.codes).map( (it) => it.code)).to.contain('617')
+    })
+  })
+
+  it("Can filter Healthcare Elements by union filter", async function () {
+    const tagFilter = new HealthcareElementFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byLabelCodeFilter(
+        'SNOMEDCT',
+        '617'
+      )
+    const filterByTagOrCode = await new HealthcareElementFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byLabelCodeFilter(
+        undefined,
+        undefined,
+        'SNOMEDCT',
+        '617'
+      )
+      .union([tagFilter])
+      .build()
+
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(filterByTagOrCode)
+
+    expect(elements.rows.length).to.be.greaterThan(0)
+    elements.rows.forEach( (he) => {
+      expect(he).to.satisfy( (e: HealthcareElement) => {
+        return Array.from(e.codes).some( (it) => it.type === 'SNOMEDCT' && it.code === '617')
+          || Array.from(e.tags).some( (it) => it.type === 'SNOMEDCT' && it.code === '617')
+      })
+    })
+  }).timeout(60000)
+
+  it("Can filter Healthcare Elements by implicit intersection filter", async function () {
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(
+      await new HealthcareElementFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byIds([he1.id!, he2.id!, he3.id!])
+        .byLabelCodeFilter(
+          'SNOMEDCT',
+          '617'
+        )
+        .build()
+    )
+    expect(elements.rows.length).to.be.equal(1)
+    elements.rows.forEach( (he) => {
+      expect(Array.from(he.tags).map( (it) => it.code)).to.contain('617')
+      expect(Array.from(he.tags).map( (it) => it.type)).to.contain('SNOMEDCT')
+    })
+  })
+
+  it("Can filter Healthcare Elements by explicit intersection filter", async function () {
+    const tagFilter = new HealthcareElementFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byLabelCodeFilter(
+        'SNOMEDCT',
+        '617'
+      )
+
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(
+      await new HealthcareElementFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byIds([he1.id!, he2.id!, he3.id!])
+        .intersection([tagFilter])
+        .build()
+    )
+    expect(elements.rows.length).to.be.equal(1)
+    elements.rows.forEach( (he) => {
+      expect(Array.from(he.tags).map( (it) => it.code)).to.contain('617')
+      expect(Array.from(he.tags).map( (it) => it.type)).to.contain('SNOMEDCT')
+    })
+  })
+
+  it("Intersection between disjoint sets return empty result", async function () {
+    const tagFilter = new HealthcareElementFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .byLabelCodeFilter(
+        'SNOMEDCT',
+        '617'
+      )
+
+    const elements = await hcp1Api.healthcareElementApi.filterHealthcareElement(
+      await new HealthcareElementFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byLabelCodeFilter(
+          undefined,
+          undefined,
+          'SNOMEDCT',
+          '617'
+        )
+        .intersection([tagFilter])
+        .build()
+    )
+
+    expect(elements.rows.length).to.be.equal(0)
+  })
+
+});

--- a/test/filter/medical-device-filters-tests.ts
+++ b/test/filter/medical-device-filters-tests.ts
@@ -1,0 +1,132 @@
+import 'isomorphic-fetch';
+import {
+  getEnvironmentInitializer,
+  getEnvVariables,
+  hcp1Username,
+  setLocalStorage,
+  TestUtils,
+  TestVars
+} from "../test-utils";
+import {MedTechApi} from "../../src/apis/MedTechApi";
+import {User} from "../../src/models/User";
+import {MedicalDeviceFilter} from "../../src/filter";
+import {expect} from "chai";
+import {MedicalDevice} from "../../src/models/MedicalDevice";
+
+setLocalStorage(fetch);
+
+let env: TestVars;
+let hcp1Api: MedTechApi
+let hcp1User: User
+let md1: MedicalDevice
+let md2: MedicalDevice
+let md3: MedicalDevice
+
+describe("Medical Device Filters Test", function () {
+
+  before(async function () {
+    this.timeout(60000)
+    const initializer = await getEnvironmentInitializer();
+    env = await initializer.execute(getEnvVariables());
+
+    const hcp1ApiAndUser = await TestUtils.createMedTechApiAndLoggedUserFor(
+      env.iCureUrl,
+      env.dataOwnerDetails[hcp1Username]);
+    hcp1Api = hcp1ApiAndUser.api;
+    hcp1User = hcp1ApiAndUser.user;
+
+    md1 = await hcp1Api.medicalDeviceApi.createOrModifyMedicalDevice(
+      new MedicalDevice({
+        name: 'Giskard'
+      })
+    )
+
+    md2 = await hcp1Api.medicalDeviceApi.createOrModifyMedicalDevice(
+      new MedicalDevice({
+        name: 'Daneel'
+      })
+    )
+
+    md3 = await hcp1Api.medicalDeviceApi.createOrModifyMedicalDevice(
+      new MedicalDevice({
+        name: 'Marvin'
+      })
+    )
+
+  });
+
+  it("MedicalDeviceByIds test - Success", async function () {
+    const devices = await hcp1Api.medicalDeviceApi.filterMedicalDevices(
+      await new MedicalDeviceFilter()
+        .byIds([md1.id!, md2.id!])
+        .build()
+    )
+
+    expect(!!devices).to.eq(true)
+    expect(devices.rows.length).to.eq(2)
+    expect(devices.rows.map( (it) => it.id)).to.contain(md1.id)
+    expect(devices.rows.map( (it) => it.id)).to.contain(md2.id)
+  })
+
+  it("MedicalDeviceByIds test - Failure", async function () {
+    const devices = await hcp1Api.medicalDeviceApi.filterMedicalDevices(
+      await new MedicalDeviceFilter()
+        .byIds(["DEFINITELY_NON_EXISTING"])
+        .build()
+    )
+
+    expect(devices.rows.length).to.be.equal(0)
+  })
+
+  it("If no parameter is specified, all medical devices are returned", async function () {
+    const devices = await hcp1Api.medicalDeviceApi.filterMedicalDevices(
+      await new MedicalDeviceFilter()
+        .build()
+    )
+
+    expect(devices.rows.length).to.be.greaterThan(0)
+  })
+
+  it("Can filter medical devices by union filter", async function () {
+    const firstDeviceFilter = new MedicalDeviceFilter().byIds([md1.id!])
+    const otherDevicesFilter = await new MedicalDeviceFilter()
+      .byIds([md3.id!, md2.id!])
+      .union([firstDeviceFilter])
+      .build()
+
+    const devices = await hcp1Api.medicalDeviceApi.filterMedicalDevices(otherDevicesFilter)
+
+    expect(devices.rows.length).to.be.equal(3)
+    expect(devices.rows.map( (it) => it.id)).to.contain(md1.id!)
+    expect(devices.rows.map( (it) => it.id)).to.contain(md2.id!)
+    expect(devices.rows.map( (it) => it.id)).to.contain(md3.id!)
+  })
+
+  it("Can filter medical devices by explicit intersection filter", async function () {
+    const partialIdFilter = new MedicalDeviceFilter().byIds([md3.id!, md2.id!])
+
+    const devices = await hcp1Api.medicalDeviceApi.filterMedicalDevices(
+      await new MedicalDeviceFilter()
+        .byIds([md1.id!, md2.id!])
+        .intersection([partialIdFilter])
+        .build()
+    )
+
+    expect(devices.rows.length).to.be.equal(1)
+    expect(devices.rows.map( (it) => it.id)).to.contain(md2.id!)
+  })
+
+  it("Intersection between disjoint sets return empty result", async function () {
+    const partialIdFilter = new MedicalDeviceFilter().byIds([md3.id!, md2.id!])
+
+    const devices = await hcp1Api.medicalDeviceApi.filterMedicalDevices(
+      await new MedicalDeviceFilter()
+        .byIds([md1.id!])
+        .intersection([partialIdFilter])
+        .build()
+    )
+
+    expect(devices.rows.length).to.be.equal(0)
+  })
+
+});

--- a/test/filter/notification-filters-tests.ts
+++ b/test/filter/notification-filters-tests.ts
@@ -1,0 +1,193 @@
+import 'isomorphic-fetch';
+import {MedTechApi} from "../../src/apis/MedTechApi";
+import {User} from "../../src/models/User";
+import {
+  getEnvironmentInitializer,
+  getEnvVariables,
+  hcp1Username,
+  setLocalStorage,
+  TestUtils,
+  TestVars
+} from "../test-utils";
+import {NotificationFilter} from "../../src/filter";
+import {expect} from "chai";
+import {Notification, NotificationTypeEnum} from "../../src/models/Notification";
+
+setLocalStorage(fetch);
+
+let env: TestVars;
+let hcp1Api: MedTechApi
+let hcp1User: User
+
+let notification1: Notification
+let notification2: Notification
+let notification3: Notification
+
+let startingDate: Date
+
+describe("Notification Filters Tests", function () {
+
+  before(async function () {
+    this.timeout(60000)
+    const initializer = await getEnvironmentInitializer();
+    env = await initializer.execute(getEnvVariables());
+
+    const hcp1ApiAndUser = await TestUtils.createMedTechApiAndLoggedUserFor(
+      env.iCureUrl,
+      env.dataOwnerDetails[hcp1Username]);
+    hcp1Api = hcp1ApiAndUser.api;
+    hcp1User = hcp1ApiAndUser.user;
+
+    startingDate = new Date()
+
+    notification1 = (await hcp1Api.notificationApi.createOrModifyNotification(
+      new Notification({
+        status: "pending",
+        created: startingDate.getTime() - 10000,
+        type: NotificationTypeEnum.KEY_PAIR_UPDATE
+      }),
+      hcp1User.healthcarePartyId!
+    ))!
+
+    notification2 = (await hcp1Api.notificationApi.createOrModifyNotification(
+      new Notification({
+        status: "pending",
+        created: startingDate.getTime() - 10000,
+        type: NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS
+      }),
+      hcp1User.healthcarePartyId!
+    ))!
+
+    notification3 = (await hcp1Api.notificationApi.createOrModifyNotification(
+      new Notification({
+        status: "ongoing",
+        created: startingDate.getTime() + 10000,
+        type: NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS
+      }),
+      hcp1User.healthcarePartyId!
+    ))!
+
+  });
+
+  it("If no parameter is specified, all the Notifications are returned", async function () {
+    const notes = await hcp1Api.notificationApi.filterNotifications(
+      await new NotificationFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .build()
+    )
+
+    expect(notes.rows.length).to.be.greaterThan(0)
+  })
+
+  it("Can filter Notifications by ids", async function () {
+    const notes = await hcp1Api.notificationApi.filterNotifications(
+      await new NotificationFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .byIds([notification1.id!, notification2.id!])
+        .build()
+    )
+
+    expect(notes.rows.length).to.be.equal(2)
+    expect(notes.rows.map( (it) => it.id )).to.contain(notification1.id)
+    expect(notes.rows.map( (it) => it.id )).to.contain(notification2.id)
+  })
+
+  it("Can filter Notifications by type", async function () {
+    const notes = await hcp1Api.notificationApi.filterNotifications(
+      await new NotificationFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .withType(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+        .build()
+    )
+
+    expect(notes.rows.length).to.be.greaterThan(0)
+    notes.rows.forEach( (note) => {
+      expect(note.type).to.be.equal(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+    })
+  })
+
+  it("Can filter Notifications after date", async function () {
+    const notes = await hcp1Api.notificationApi.filterNotifications(
+      await new NotificationFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .afterDate(startingDate.getTime())
+        .build()
+    )
+
+    expect(notes.rows.length).to.be.greaterThan(0)
+    notes.rows.forEach( (note) => {
+      expect(note.created).to.be.greaterThanOrEqual(startingDate.getTime())
+    })
+  })
+
+  it("Can filter Notifications by union filter", async function () {
+    const afterDateFilter = new NotificationFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .afterDate(startingDate.getTime())
+
+    const filterAfterDateOrType = await new NotificationFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .withType(NotificationTypeEnum.KEY_PAIR_UPDATE)
+      .union([afterDateFilter])
+      .build()
+
+    const notes = await hcp1Api.notificationApi.filterNotifications(filterAfterDateOrType)
+
+    expect(notes.rows.length).to.be.greaterThan(0)
+    notes.rows.forEach( (note) => {
+      expect(note).to.satisfy( (n: Notification) => {
+        return (!!n.created && n.created >= startingDate.getTime() )
+          || n.type === NotificationTypeEnum.KEY_PAIR_UPDATE
+      })
+    })
+  })
+
+  it("Can filter Notifications by implicit intersection filter", async function () {
+    const filterAfterDateOrType = await new NotificationFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .withType(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+      .afterDate(startingDate.getTime())
+      .build()
+
+    const notes = await hcp1Api.notificationApi.filterNotifications(filterAfterDateOrType)
+
+    expect(notes.rows.length).to.be.greaterThan(0)
+    notes.rows.forEach( (note) => {
+      expect(note.type).to.be.equal(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+      expect(note.created).to.be.greaterThanOrEqual(startingDate.getTime())
+    })
+  })
+
+  it("Can filter Notifications by explicit intersection filter", async function () {
+    const afterDateFilter = new NotificationFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .afterDate(startingDate.getTime())
+
+    const filterAfterDateOrType = await new NotificationFilter()
+      .forDataOwner(hcp1User.healthcarePartyId!)
+      .withType(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+      .intersection([afterDateFilter])
+      .build()
+
+    const notes = await hcp1Api.notificationApi.filterNotifications(filterAfterDateOrType)
+
+    expect(notes.rows.length).to.be.greaterThan(0)
+    notes.rows.forEach( (note) => {
+      expect(note.type).to.be.equal(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+      expect(note.created).to.be.greaterThanOrEqual(startingDate.getTime())
+    })
+  })
+
+  it("Intersection between disjoint sets return empty result", async function () {
+    const notes = await hcp1Api.notificationApi.filterNotifications(
+      await new NotificationFilter()
+        .forDataOwner(hcp1User.healthcarePartyId!)
+        .withType(NotificationTypeEnum.NEW_USER_OWN_DATA_ACCESS)
+        .byIds([notification1.id!])
+        .build()
+    )
+
+    expect(notes.rows.length).to.be.equal(0)
+  })
+
+});

--- a/test/filter/patient-filters-test.ts
+++ b/test/filter/patient-filters-test.ts
@@ -1,0 +1,163 @@
+import 'isomorphic-fetch';
+import {
+  getEnvironmentInitializer,
+  getEnvVariables,
+  hcp1Username, setLocalStorage,
+  TestUtils,
+  TestVars
+} from "../test-utils";
+import {MedTechApi} from "../../src/apis/MedTechApi";
+import {User} from "../../src/models/User";
+import {Patient} from "../../src/models/Patient";
+import {expect} from "chai";
+import {PatientFilter} from "../../src/filter";
+
+setLocalStorage(fetch)
+
+let env: TestVars
+let api: MedTechApi
+let user: User
+
+const now = new Date()
+
+function getYear(dateOfBirth?: number) {
+  expect(!!dateOfBirth).to.be.true
+  return Math.floor(dateOfBirth! / 10000)
+}
+
+describe("Patient Filters Test", function () {
+
+  before(async function () {
+    this.timeout(600000)
+    const initializer = await getEnvironmentInitializer();
+    env = await initializer.execute(getEnvVariables());
+
+    const apiAndUser = await TestUtils.createMedTechApiAndLoggedUserFor(
+      env!.iCureUrl,
+      env.dataOwnerDetails[hcp1Username])
+    api = apiAndUser.api
+    user = apiAndUser.user
+
+    await api.patientApi.createOrModifyPatient(
+      new Patient({
+        firstName: 'Arthur',
+        lastName: 'Dent',
+        gender: "male",
+        dateOfBirth: parseInt(`${now.getFullYear() - 42}0214`)
+      })
+    )
+
+    await api.patientApi.createOrModifyPatient(
+      new Patient({
+        firstName: 'Trillian',
+        lastName: 'Astra',
+        gender: "female",
+        dateOfBirth: parseInt(`${now.getFullYear() - 42}0111`)
+      })
+    )
+
+    await api.patientApi.createOrModifyPatient(
+      new Patient({
+        firstName: 'Zaphod',
+        lastName: 'Beeblebrox',
+        gender: "indeterminate"
+      })
+    )
+  });
+
+  it("Can filter Patients", async () => {
+    const filter = await new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .ofAge(42)
+      .build()
+    const patients = await api.patientApi.filterPatients(filter)
+    expect(patients.rows.length).to.be.greaterThan(0)
+    patients.rows.forEach( (p) => {
+      expect(!!p.dateOfBirth).to.be.true
+      const year = Math.floor(p.dateOfBirth! / 10000)
+      expect(now.getFullYear() - year).to.be.eq(42)
+    })
+  })
+
+  it("Can filter Specifying only data owner", async () => {
+    const filter = await new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .build()
+    const patients = await api.patientApi.filterPatients(filter)
+    expect(patients.rows.length).to.be.greaterThan(0)
+    patients.rows.forEach( (p) => {
+      expect(Object.keys(p.systemMetaData?.delegations ?? {})).to.contain(user.healthcarePartyId!)
+    })
+  })
+
+  it("Can filter Patients with implicit intersection filter", async () => {
+    const intersectionFilter = await new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .ofAge(42)
+      .byGenderEducationProfession("female")
+      .build()
+
+    const patients = await api.patientApi.filterPatients(intersectionFilter)
+    expect(patients.rows.length).to.be.greaterThan(0)
+    patients.rows.forEach( (p) => {
+      expect(p.gender).to.be.eq("female")
+      const year = getYear(p.dateOfBirth)
+      expect(now.getFullYear() - year).to.be.eq(42)
+    })
+  })
+
+
+  it("Can filter Patients with explicit intersection filter", async () => {
+    const filterByAge = new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .ofAge(42)
+
+    const filterByGenderAndAge = await new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .byGenderEducationProfession("female")
+      .intersection([filterByAge])
+      .build()
+
+    const patients = await api.patientApi.filterPatients(filterByGenderAndAge)
+    expect(patients.rows.length).to.be.greaterThan(0)
+    patients.rows.forEach( (p) => {
+      expect(p.gender).to.be.eq("female")
+      const year = getYear(p.dateOfBirth)
+      expect(now.getFullYear() - year).to.be.eq(42)
+    })
+  })
+
+  it("If the set are disjoint, the intersection result is empty", async () => {
+    const filterByMale = new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .byGenderEducationProfession("male")
+
+    const filterByFemaleAndMale = await new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .byGenderEducationProfession("female")
+      .intersection([filterByMale])
+      .build()
+
+    const patients = await api.patientApi.filterPatients(filterByFemaleAndMale)
+    expect(patients.rows.length).to.be.equal(0)
+  })
+
+  it("Can filter Patients with union filter", async () => {
+    const filterFemales = new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .byGenderEducationProfession("female")
+
+    const filterFemaleOrIndeterminate = await new PatientFilter()
+      .forDataOwner(user.healthcarePartyId!)
+      .byGenderEducationProfession("indeterminate")
+      .union([filterFemales])
+      .build()
+
+    const patients = await api.patientApi.filterPatients(filterFemaleOrIndeterminate)
+    expect(patients.rows.length).to.be.greaterThan(0)
+    patients.rows.forEach( (p) => {
+      expect(p.gender).to.be.oneOf(["female", "indeterminate"])
+    })
+  })
+
+})

--- a/test/filter/user-filters-test.ts
+++ b/test/filter/user-filters-test.ts
@@ -3,26 +3,28 @@ import {MedTechApi} from "../../src/apis/MedTechApi";
 import {User} from "../../src/models/User";
 import {
   getEnvironmentInitializer,
-  getEnvVariables,
+  getEnvVariables, getTempEmail,
   hcp1Username, patUsername,
   setLocalStorage,
   TestUtils,
   TestVars
 } from "../test-utils";
 import {UserFilter} from "../../src/filter";
-import {assert, expect} from "chai";
+import {expect} from "chai";
 
 setLocalStorage(fetch);
 
-let env: TestVars | undefined;
-let hcp1Api: MedTechApi | undefined = undefined;
-let hcp1User: User | undefined = undefined;
-let patApi: MedTechApi | undefined = undefined;
-let patUser: User | undefined = undefined;
+let env: TestVars;
+let hcp1Api: MedTechApi
+let hcp1User: User
+let patApi: MedTechApi
+let patUser: User
+let newUser: User
 
 describe("User Filters Test", function () {
 
   before(async function () {
+    this.timeout(60000)
     const initializer = await getEnvironmentInitializer();
     env = await initializer.execute(getEnvVariables());
 
@@ -37,31 +39,110 @@ describe("User Filters Test", function () {
       env.dataOwnerDetails[patUsername]);
     patApi = patApiAndUser.api;
     patUser = patApiAndUser.user;
+
+    newUser = await hcp1Api.userApi.createOrModifyUser(
+      new User({
+        name: 'Marvin',
+        login: getTempEmail()
+      })
+    )
+
   });
 
   it("UsersByPatientIdFilter test - Success", async function () {
-    const users = await hcp1Api!.userApi.filterUsers(
+    const users = await hcp1Api.userApi.filterUsers(
       await new UserFilter()
-        .byPatientId(patUser!.patientId!)
+        .byPatientId(patUser.patientId!)
         .build()
-    );
+    )
 
-    expect(!!users).to.eq(true);
-    expect(users.rows.length).to.gt(0);
+    expect(!!users).to.eq(true)
+    expect(users.rows.length).to.gt(0)
     users.rows.forEach( (user) => {
-      expect(user.patientId).to.eq(patUser!.patientId!);
-    });
+      expect(user.patientId).to.eq(patUser.patientId!)
+    })
   })
 
   it("UsersByPatientIdFilter test - Failure", async function () {
-    const users = await hcp1Api!.userApi.filterUsers(
+    const users = await hcp1Api.userApi.filterUsers(
       await new UserFilter()
         .byPatientId("THIS IS DOOMED TO FAIL")
         .build()
-    );
+    )
 
-    assert(!!users)
-    assert(users.rows.length == 0)
+    expect(users.rows.length).to.be.equal(0)
   })
+
+  it("If no parameter is specified, all users are returned", async function () {
+    const filter = await new UserFilter().build()
+    const users = await hcp1Api.userApi.filterUsers(filter)
+
+    expect(users.rows.length).to.be.greaterThan(0)
+  }).timeout(60000)
+
+  it("Can filter User by Id", async function () {
+    const users = await hcp1Api.userApi.filterUsers(
+      await new UserFilter()
+        .byIds([patUser.id!, newUser.id!])
+        .build()
+    )
+
+    expect(users.rows.length).to.be.equal(2)
+    expect(users.rows.map( (it) => it.id)).to.contain(patUser.id!)
+    expect(users.rows.map( (it) => it.id)).to.contain(newUser.id!)
+  }).timeout(60000)
+
+  it("Can filter User by union filter", async function () {
+    const idFilter = new UserFilter().byIds([newUser.id!])
+    const filterByIdOrPatient = await new UserFilter()
+      .byPatientId(patUser.patientId!)
+      .union([idFilter])
+      .build()
+
+    const users = await hcp1Api.userApi.filterUsers(filterByIdOrPatient)
+
+    expect(users.rows.length).to.be.greaterThan(0)
+    expect(users.rows.map( (it) => it.id)).to.contain(patUser.id!)
+    expect(users.rows.map( (it) => it.id)).to.contain(newUser.id!)
+  }).timeout(60000)
+
+  it("Can filter user by implicit intersection filter", async function () {
+    const users = await hcp1Api.userApi.filterUsers(
+      await new UserFilter()
+        .byPatientId(patUser.patientId!)
+        .byIds([patUser.id!, newUser.id!])
+        .build()
+    )
+
+    expect(users.rows.length).to.be.equal(1)
+    expect(users.rows.map( (it) => it.id)).to.contain(patUser.id!)
+  }).timeout(60000)
+
+  it("Can filter user by explicit intersection filter", async function () {
+    const patientIdFilter = new UserFilter().byPatientId(patUser.patientId!)
+
+    const users = await hcp1Api.userApi.filterUsers(
+      await new UserFilter()
+        .intersection([patientIdFilter])
+        .byIds([patUser.id!, newUser.id!])
+        .build()
+    )
+
+    expect(users.rows.length).to.be.equal(1)
+    expect(users.rows.map( (it) => it.id)).to.contain(patUser.id!)
+  }).timeout(60000)
+
+  it("Intersection between disjoint sets return empty result", async function () {
+    const patientIdFilter = new UserFilter().byPatientId(patUser.patientId!)
+
+    const users = await hcp1Api.userApi.filterUsers(
+      await new UserFilter()
+        .intersection([patientIdFilter])
+        .byIds([newUser.id!])
+        .build()
+    )
+
+    expect(users.rows.length).to.be.equal(0)
+  }).timeout(60000)
 
 });

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { medTechApi, MedTechApi } from '../src/apis/MedTechApi'
 import { User } from '../src/models/User'
 import { webcrypto } from 'crypto'
-import { Api, hex2ua, KeyStorageFacade, StorageFacade } from '@icure/api'
+import {Api, hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
 import { AnonymousMedTechApiBuilder } from '../src/apis/AnonymousMedTechApi'
 import axios, { Method } from 'axios'
 import { Patient } from '../src/models/Patient'
@@ -109,6 +109,7 @@ export const hcp1Username = process.env.ICURE_TS_TEST_HCP_USER ?? getTempEmail()
 export const hcp2Username = process.env.ICURE_TS_TEST_HCP_2_USER ?? getTempEmail()
 export const hcp3Username = process.env.ICURE_TS_TEST_HCP_3_USER ?? getTempEmail()
 export const patUsername = process.env.ICURE_TS_TEST_PAT_USER ?? getTempEmail()
+const registerThrottlingLimit = 10000
 
 export class ICureTestEmail implements EmailMessageFactory {
   dataOwner: HealthcareProfessional | Patient
@@ -154,7 +155,17 @@ export async function getEnvironmentInitializer(): Promise<EnvInitializer> {
   return cachedInitializer
 }
 
+function returnWithinBoundaries(element: number, upperBound: number, lowerBound: number): number {
+  if ( element <= upperBound && element >= lowerBound) return element
+  else if ( element > upperBound) return  upperBound
+  else return lowerBound
+}
+
 export class TestUtils {
+
+  private static registerAverageWait = 10000
+  private static lastRegisterCall = 0
+
   static async createDefaultPatient(medTechApi: MedTechApi): Promise<Patient> {
     return medTechApi.patientApi.createOrModifyPatient(
       new Patient({
@@ -206,6 +217,14 @@ export class TestUtils {
     storage?: StorageFacade<string>,
     keyStorage?: KeyStorageFacade
   ): Promise<{ api: MedTechApi; user: User; token: string }> {
+
+    if( (new Date().getTime() - this.lastRegisterCall) < registerThrottlingLimit) {
+      const throttlingWait = returnWithinBoundaries( (registerThrottlingLimit - this.registerAverageWait)*5 - this.registerAverageWait, registerThrottlingLimit, 0)
+      await sleep(throttlingWait)
+      this.registerAverageWait = this.registerAverageWait + (throttlingWait - this.registerAverageWait)/5
+    }
+    this.lastRegisterCall = new Date().getTime()
+
     const builder = new AnonymousMedTechApiBuilder()
       .withICureBaseUrl(iCureUrl)
       .withMsgGwUrl(msgGtwUrl)

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { medTechApi, MedTechApi } from '../src/apis/MedTechApi'
 import { User } from '../src/models/User'
 import { webcrypto } from 'crypto'
-import {Api, hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
+import { hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
 import { AnonymousMedTechApiBuilder } from '../src/apis/AnonymousMedTechApi'
 import axios, { Method } from 'axios'
 import { Patient } from '../src/models/Patient'

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,10 +221,10 @@
     uuid "^8.3.2"
     uuid-encoder "^1.1.0"
 
-"@icure/test-setup@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@icure/test-setup/-/test-setup-0.0.33.tgz#c2c20b917baab2d96c63d69c0c388d990448f33c"
-  integrity sha512-B3zffRYteXOzkTjEM4TDR6hYK2vTVmtPP5yJ73yDDRuQM+bvxufoCjXGeJhsqsibEz4lGfsR+V7gdtsGrzHJ3A==
+"@icure/test-setup@^0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@icure/test-setup/-/test-setup-0.0.35.tgz#64f9dfa511936d086b1f01482b15076c664cd9e7"
+  integrity sha512-wiwmxSaqiXY6nfBEjt5y2rK92MX1Ie7/8FhNjNTMM54SfKLjRo2mM/Q312nwgQX8MaD4cBt/7EKOlIloqHm8og==
   dependencies:
     "@icure/api" "^6.0.3"
     "@types/react-dom" "^18.0.6"


### PR DESCRIPTION
### Bug Fixing

- Fixed a bug that caused the Union filter to behave as the Intersection filter.
- Fixed a bug that made impossible to instanitate the Intersection filter without calling the `intersection` method.

### Enhancement

- Added the `regions` field to the `Coding` class.

### New method signature
The `byRegionTypeLabelLanguage(region?: string, type?: string, language?: string, label?: string): CodingFilter` method in the `CodingFilter` class was changed to:

```ts
  byRegionLanguageTypeLabel(region?: string, language?: string, type?: string, label?: string): CodingFilter
```