### PR TITLE
Unable to login using completeAuthentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ws": "^8.5.0"
   },
   "devDependencies": {
-    "@icure/test-setup": "^0.0.33",
+    "@icure/test-setup": "^0.0.35",
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/isomorphic-fetch": "^0.0.36",

--- a/src/apis/AuthenticationApi.ts
+++ b/src/apis/AuthenticationApi.ts
@@ -1,11 +1,10 @@
-import {AuthenticationProcess} from "../models/AuthenticationProcess";
-import {AuthenticationResult} from "../models/AuthenticationResult";
+import { AuthenticationProcess } from '../models/AuthenticationProcess'
+import { AuthenticationResult } from '../models/AuthenticationResult'
 
 /**
  * The AuthenticationApi interface provides methods to authenticate and register users.
  */
 export interface AuthenticationApi {
-
   /**
    * Starts the authentication of a user by sending him/her a validation code by email and/or by SMS.
    * Use this service if you would like to register or login your user in the iCure system.
@@ -53,7 +52,7 @@ export interface AuthenticationApi {
   completeAuthentication(
     process: AuthenticationProcess,
     validationCode: string,
-    getUserKeypair: ((userId: string) => Promise<{ privateKey: string, publicKey: string }>),
+    getUserKeypair: (userId: string) => Promise<{ privateKey: string; publicKey: string }>
   ): Promise<AuthenticationResult>
 
   /**
@@ -69,9 +68,5 @@ export interface AuthenticationApi {
    * @return The result of the authentication and the related MedTechApi object corresponding to the newly authenticated
    * user.
    */
-  authenticateAndAskAccessToItsExistingData(
-    userLogin: string,
-    shortLivedToken: string,
-    getUserKeypair: ((userId: string) => Promise<{ privateKey: string, publicKey: string }>),
-  ): Promise<AuthenticationResult>
+  authenticateAndAskAccessToItsExistingData(userLogin: string, shortLivedToken: string): Promise<AuthenticationResult>
 }

--- a/src/apis/DataOwnerApi.ts
+++ b/src/apis/DataOwnerApi.ts
@@ -21,7 +21,7 @@ export interface DataOwnerApi {
    *
    * @return The response will contain the RSA keyPair generated for the provided user;
    */
-  initCryptoFor(user: User, userKeyPair?: { publicKey: string; privateKey: string }): Promise<void>
+  initCryptoFor(user: User, userKeyPair?: { publicKey: string; privateKey: string }): Promise<{ publicKey: string; privateKey: string }[]>
 
   giveAccessBackTo(ownerId: string, ownerNewPublicKey: string): Promise<boolean>
 }

--- a/src/apis/MedTechApi.ts
+++ b/src/apis/MedTechApi.ts
@@ -267,9 +267,9 @@ export class MedTechApi {
     await this._keyStorage.storeKeyPair(`${dataOwnerId}.${keyPair.publicKey.slice(-32)}`, jwk)
   }
 
-  async initUserCrypto(keyPair?: { publicKey: string; privateKey: string }): Promise<void> {
+  async initUserCrypto(keyPair?: { publicKey: string; privateKey: string }): Promise<{ publicKey: string; privateKey: string }[]> {
     const currentUser = await this.userApi.getLoggedUser()
-    await this._dataOwnerApi.initCryptoFor(currentUser, keyPair)
+    return await this._dataOwnerApi.initCryptoFor(currentUser, keyPair)
   }
 }
 

--- a/src/apis/impl/DataOwnerApiImpl.ts
+++ b/src/apis/impl/DataOwnerApiImpl.ts
@@ -69,7 +69,7 @@ export class DataOwnerApiImpl implements DataOwnerApi {
     return dataOwnerId
   }
 
-  async initCryptoFor(user: User, keyPair?: { publicKey: string; privateKey: string }): Promise<void> {
+  async initCryptoFor(user: User, keyPair?: { publicKey: string; privateKey: string }): Promise<{ publicKey: string; privateKey: string }[]> {
     const dataOwnerId = this.getDataOwnerIdOf(user)
     const dataOwner = await this.cryptoApi.getDataOwner(dataOwnerId).catch((e) => {
       throw this.errorHandler.createErrorFromAny(e)
@@ -115,7 +115,9 @@ export class DataOwnerApiImpl implements DataOwnerApi {
           privateKey: privateKey,
         })
       }
+      return [{ publicKey, privateKey }]
     }
+    return userKeyPairs.map(({ publicKey, privateKey }) => ({ publicKey: jwk2spki(publicKey), privateKey: jwk2pkcs8(privateKey) }))
   }
 
   private async _updateUserToAddNewlyCreatedPublicKey(user: User, dataOwner: Patient | Device | HealthcareParty, dataOwnerPublicKey: string) {

--- a/src/apis/impl/DataOwnerApiImpl.ts
+++ b/src/apis/impl/DataOwnerApiImpl.ts
@@ -117,7 +117,7 @@ export class DataOwnerApiImpl implements DataOwnerApi {
       }
       return [{ publicKey, privateKey }]
     }
-    return userKeyPairs.map(({ publicKey, privateKey }) => ({ publicKey: jwk2spki(publicKey), privateKey: jwk2pkcs8(privateKey) }))
+    return userKeyPairs.map((kp) => ({ publicKey: jwk2spki(kp.publicKey), privateKey: jwk2pkcs8(kp.privateKey) }))
   }
 
   private async _updateUserToAddNewlyCreatedPublicKey(user: User, dataOwner: Patient | Device | HealthcareParty, dataOwnerPublicKey: string) {

--- a/src/models/AuthenticationResult.ts
+++ b/src/models/AuthenticationResult.ts
@@ -1,21 +1,21 @@
-import {MedTechApi} from "../apis/MedTechApi";
+import { MedTechApi } from '../apis/MedTechApi'
 
 export class AuthenticationResult {
   constructor(json: IAuthenticationResult) {
     Object.assign(this as AuthenticationResult, json)
   }
 
-  'medTechApi': MedTechApi;
-  'keyPair': { privateKey: string, publicKey: string };
-  'token': string;
-  'groupId': string;
-  'userId': string;
+  'medTechApi': MedTechApi
+  'keyPairs': { privateKey: string; publicKey: string }[]
+  'token': string
+  'groupId': string
+  'userId': string
 }
 
 interface IAuthenticationResult {
-  'medTechApi'?: MedTechApi;
-  'keyPair'?: { privateKey: string, publicKey: string };
-  'token'?: string;
-  'groupId'?: string;
-  'userId'?: string;
+  medTechApi?: MedTechApi
+  keyPairs?: { privateKey: string; publicKey: string }[]
+  token?: string
+  groupId?: string
+  userId?: string
 }

--- a/test/apis/authentication-api.ts
+++ b/test/apis/authentication-api.ts
@@ -174,7 +174,7 @@ describe('Authentication API', () => {
     assert(currentUser)
     assert(currentUser.patientId != null)
 
-    const keyPair = await api.initUserCrypto()
+    await api.initUserCrypto()
     try {
       await api.initUserCrypto()
     } catch (e) {

--- a/test/apis/authentication-api.ts
+++ b/test/apis/authentication-api.ts
@@ -278,7 +278,7 @@ describe('Authentication API', () => {
     const foundUser = await loginAuthResult.medTechApi.userApi.getLoggedUser()
     await loginAuthResult.medTechApi.cryptoApi.loadKeyPairsAsTextInBrowserLocalStorage(
       foundUser.healthcarePartyId ?? foundUser.patientId ?? foundUser.deviceId!,
-      hex2ua(loginAuthResult.keyPair.privateKey)
+      hex2ua(loginAuthResult.keyPairs[0].privateKey)
     )
 
     // Then
@@ -298,12 +298,12 @@ describe('Authentication API', () => {
 
     // When he gave access back with his previous key
     patApiAndUser.api.cryptoApi.emptyHcpCache(currentPatient.id!)
-    const accessBack = await patApiAndUser.api.dataOwnerApi.giveAccessBackTo(currentPatient.id!, loginAuthResult.keyPair.publicKey)
+    const accessBack = await patApiAndUser.api.dataOwnerApi.giveAccessBackTo(currentPatient.id!, loginAuthResult.keyPairs[0].publicKey)
     expect(accessBack).to.be.true
 
     // Then
     const updatedApi = await medTechApi(loginAuthResult.medTechApi).build()
-    await updatedApi.initUserCrypto(loginAuthResult.keyPair)
+    await updatedApi.initUserCrypto(loginAuthResult.keyPairs[0])
 
     const previousDataSample = await updatedApi.dataSampleApi.getDataSample(createdDataSample.id!)
     expect(previousDataSample).to.not.be.undefined
@@ -349,7 +349,7 @@ describe('Authentication API', () => {
     const foundUser = await loginAuthResult.medTechApi.userApi.getLoggedUser()
     await loginAuthResult.medTechApi.cryptoApi.loadKeyPairsAsTextInBrowserLocalStorage(
       foundUser.healthcarePartyId ?? foundUser.patientId ?? foundUser.deviceId!,
-      hex2ua(loginAuthResult.keyPair.privateKey)
+      hex2ua(loginAuthResult.keyPairs[0].privateKey)
     )
 
     // Then
@@ -391,7 +391,7 @@ describe('Authentication API', () => {
 
     // Then
     const updatedApi = await medTechApi(loginAuthResult.medTechApi).build()
-    await updatedApi.initUserCrypto(loginAuthResult.keyPair)
+    await updatedApi.initUserCrypto(loginAuthResult.keyPairs[0])
 
     const previousDataSample = await updatedApi.dataSampleApi.getDataSample(createdDataSample.id!)
     expect(previousDataSample).to.not.be.undefined

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { medTechApi, MedTechApi } from '../src/apis/MedTechApi'
 import { User } from '../src/models/User'
 import { webcrypto } from 'crypto'
-import { Api, hex2ua, KeyStorageFacade, StorageFacade } from '@icure/api'
+import {Api, hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
 import { AnonymousMedTechApiBuilder } from '../src/apis/AnonymousMedTechApi'
 import axios, { Method } from 'axios'
 import { Patient } from '../src/models/Patient'
@@ -109,6 +109,7 @@ export const hcp1Username = process.env.ICURE_TS_TEST_HCP_USER ?? getTempEmail()
 export const hcp2Username = process.env.ICURE_TS_TEST_HCP_2_USER ?? getTempEmail()
 export const hcp3Username = process.env.ICURE_TS_TEST_HCP_3_USER ?? getTempEmail()
 export const patUsername = process.env.ICURE_TS_TEST_PAT_USER ?? getTempEmail()
+const registerThrottlingLimit = 10000
 
 export class ICureTestEmail implements EmailMessageFactory {
   dataOwner: HealthcareProfessional | Patient
@@ -154,7 +155,17 @@ export async function getEnvironmentInitializer(): Promise<EnvInitializer> {
   return cachedInitializer
 }
 
+function returnWithinBoundaries(element: number, upperBound: number, lowerBound: number): number {
+  if ( element <= upperBound && element >= lowerBound) return element
+  else if ( element > upperBound) return  upperBound
+  else return lowerBound
+}
+
 export class TestUtils {
+
+  private static registerAverageWait = 10000
+  private static lastRegisterCall = 0
+
   static async createDefaultPatient(medTechApi: MedTechApi): Promise<Patient> {
     return medTechApi.patientApi.createOrModifyPatient(
       new Patient({
@@ -206,6 +217,14 @@ export class TestUtils {
     storage?: StorageFacade<string>,
     keyStorage?: KeyStorageFacade
   ): Promise<{ api: MedTechApi; user: User; token: string }> {
+
+    if( (new Date().getTime() - this.lastRegisterCall) < registerThrottlingLimit) {
+      const throttlingWait = returnWithinBoundaries( (registerThrottlingLimit - this.registerAverageWait)*5 - this.registerAverageWait, registerThrottlingLimit, 0)
+      await sleep(throttlingWait)
+      this.registerAverageWait = this.registerAverageWait + (throttlingWait - this.registerAverageWait)/5
+    }
+    this.lastRegisterCall = new Date().getTime()
+
     const builder = new AnonymousMedTechApiBuilder()
       .withICureBaseUrl(iCureUrl)
       .withMsgGwUrl(msgGtwUrl)

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { medTechApi, MedTechApi } from '../src/apis/MedTechApi'
 import { User } from '../src/models/User'
 import { webcrypto } from 'crypto'
-import {Api, hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
+import { hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
 import { AnonymousMedTechApiBuilder } from '../src/apis/AnonymousMedTechApi'
 import axios, { Method } from 'axios'
 import { Patient } from '../src/models/Patient'

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { medTechApi, MedTechApi } from '../src/apis/MedTechApi'
 import { User } from '../src/models/User'
 import { webcrypto } from 'crypto'
-import { hex2ua, KeyStorageFacade, sleep, StorageFacade} from '@icure/api'
+import { hex2ua, KeyStorageFacade, sleep, StorageFacade } from '@icure/api'
 import { AnonymousMedTechApiBuilder } from '../src/apis/AnonymousMedTechApi'
 import axios, { Method } from 'axios'
 import { Patient } from '../src/models/Patient'
@@ -156,13 +156,12 @@ export async function getEnvironmentInitializer(): Promise<EnvInitializer> {
 }
 
 function returnWithinBoundaries(element: number, upperBound: number, lowerBound: number): number {
-  if ( element <= upperBound && element >= lowerBound) return element
-  else if ( element > upperBound) return  upperBound
+  if (element <= upperBound && element >= lowerBound) return element
+  else if (element > upperBound) return upperBound
   else return lowerBound
 }
 
 export class TestUtils {
-
   private static registerAverageWait = 10000
   private static lastRegisterCall = 0
 
@@ -217,11 +216,14 @@ export class TestUtils {
     storage?: StorageFacade<string>,
     keyStorage?: KeyStorageFacade
   ): Promise<{ api: MedTechApi; user: User; token: string }> {
-
-    if( (new Date().getTime() - this.lastRegisterCall) < registerThrottlingLimit) {
-      const throttlingWait = returnWithinBoundaries( (registerThrottlingLimit - this.registerAverageWait)*5 - this.registerAverageWait, registerThrottlingLimit, 0)
+    if (new Date().getTime() - this.lastRegisterCall < registerThrottlingLimit) {
+      const throttlingWait = returnWithinBoundaries(
+        (registerThrottlingLimit - this.registerAverageWait) * 5 - this.registerAverageWait,
+        registerThrottlingLimit,
+        0
+      )
       await sleep(throttlingWait)
-      this.registerAverageWait = this.registerAverageWait + (throttlingWait - this.registerAverageWait)/5
+      this.registerAverageWait = this.registerAverageWait + (throttlingWait - this.registerAverageWait) / 5
     }
     this.lastRegisterCall = new Date().getTime()
 
@@ -268,7 +270,7 @@ export class TestUtils {
     const foundUser = await result.medTechApi.userApi.getLoggedUser()
     await result.medTechApi.cryptoApi.loadKeyPairsAsTextInBrowserLocalStorage(
       foundUser.healthcarePartyId ?? foundUser.patientId ?? foundUser.deviceId!,
-      hex2ua(result.keyPair.privateKey)
+      hex2ua(result.keyPairs[0].privateKey)
     )
     assert(result)
     assert(result!.token != null)

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,10 +221,10 @@
     uuid "^8.3.2"
     uuid-encoder "^1.1.0"
 
-"@icure/test-setup@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@icure/test-setup/-/test-setup-0.0.33.tgz#c2c20b917baab2d96c63d69c0c388d990448f33c"
-  integrity sha512-B3zffRYteXOzkTjEM4TDR6hYK2vTVmtPP5yJ73yDDRuQM+bvxufoCjXGeJhsqsibEz4lGfsR+V7gdtsGrzHJ3A==
+"@icure/test-setup@^0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@icure/test-setup/-/test-setup-0.0.35.tgz#64f9dfa511936d086b1f01482b15076c664cd9e7"
+  integrity sha512-wiwmxSaqiXY6nfBEjt5y2rK92MX1Ie7/8FhNjNTMM54SfKLjRo2mM/Q312nwgQX8MaD4cBt/7EKOlIloqHm8og==
   dependencies:
     "@icure/api" "^6.0.3"
     "@types/react-dom" "^18.0.6"


### PR DESCRIPTION
The behavior of `_initUserAuthTokenAndCrypto` could not work with the latest changes regarding automatic key loading.

The `completeAuthentication` generated a `keyPair` anyway, whether the user already has a key or not. The handling of this scenario is already taken care of by `initUserCrypto` and providing it with a key that is not the same as the current user's keys causes an (expected) error.

However, there is a slight change in the behavior of `initUserCrypto` which now returns the user's key list, which should always be a list of size 1 to N