### PR TITLE
Fix/allow for samples deletions when cache is bypassed

### DIFF
--- a/src/apis/impl/DataSampleApiImpl.ts
+++ b/src/apis/impl/DataSampleApiImpl.ts
@@ -5,8 +5,8 @@ import { PaginatedListDataSample } from '../../models/PaginatedListDataSample'
 import { Document } from '../../models/Document'
 import { DataSampleApi } from '../DataSampleApi'
 import {
-  Contact as ContactDto,
-  Document as DocumentDto,
+  Contact as ContactDto, ContactByServiceIdsFilter,
+  Document as DocumentDto, FilterChainContact,
   FilterChainService,
   IccContactXApi,
   IccCryptoXApi,
@@ -81,6 +81,10 @@ export class DataSampleApiImpl implements DataSampleApi {
     this.dataOwnerApi = api.dataOwnerApi
     this.documentApi = api.documentApi
     this.healthcareElementApi = api.healthcareElementApi
+  }
+
+  clearContactCache() {
+    this.contactsCache.invalidateAll()
   }
 
   async createOrModifyDataSampleFor(patientId: string, dataSample: DataSample): Promise<DataSample> {
@@ -619,7 +623,9 @@ export class DataSampleApiImpl implements DataSampleApi {
 
     if (dataSampleIdsToSearch.length > 0) {
       const notCachedContacts = (
-        (await this.contactApi.filterByWithUser(currentUser, undefined, dataSampleIdsToSearch.length, undefined).catch((e) => {
+        (await this.contactApi.filterByWithUser(currentUser, undefined, dataSampleIdsToSearch.length, new FilterChainContact({
+          filter: new ContactByServiceIdsFilter({ids: dataSampleIdsToSearch}),
+        })).catch((e) => {
           throw this.errorHandler.createErrorFromAny(e)
         })) as PaginatedListContact
       ).rows

--- a/src/utils/cachedMap.ts
+++ b/src/utils/cachedMap.ts
@@ -39,11 +39,16 @@ export class CachedMap<V> {
     delete this.cachedElements[key];
   }
 
-  invalidateAll(keys: Array<string>) {
-    keys.forEach((keyToDelete) => {
-      this.invalidate(keyToDelete);
-    });
+  invalidateAll(keys?: Array<string>) {
+    if (keys) {
+      keys.forEach((keyToDelete) => {
+        this.invalidate(keyToDelete);
+      })
+    } else {
+      this.invalidateAll(Object.keys(this.cachedElements))
+    }
   }
+
 
   put(key: string, value: V) {
     if (Object.entries(this.cachedElements).length == this.maxSize) {

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -324,6 +324,23 @@ export class TestUtils {
     )
   }
 
+  static createDataSamplesForPatient(medtechApi: MedTechApi, patient: Patient) {
+    return medtechApi.dataSampleApi.createOrModifyDataSamplesFor(
+      patient.id!,
+      [
+        new DataSample({
+          labels: new Set([new CodingReference({type: 'IC-TEST', code: 'TEST'})]),
+          content: {en: new Content({stringValue: 'Hello world'})},
+        }),
+        new DataSample({
+          labels: new Set([new CodingReference({type: 'IC-TEST', code: 'TEST'})]),
+          content: {en: new Content({stringValue: 'Good night world'})},
+        })
+      ]
+    )
+  }
+
+
   static createHealthElementForPatient(medtechApi: MedTechApi, patient: Patient) {
     return medtechApi.healthcareElementApi.createOrModifyHealthcareElement(
       new HealthcareElement({


### PR DESCRIPTION
Fixes a bug where deleting several data samples at once will not work if the data samples were not previously loaded in the cache.