### PR TITLE
It is possible to pass just one authProcessId instead of both

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           ICURE_TS_TEST_MSG_GTW_URL: 'https://mock.icure.dev/msggtw'
           TEST_ENVIRONMENT: 'acceptance'
           BACKEND_TYPE: 'kraken'
+          CI: 'true'
           ICURE_TEST_GROUP_ID: ic-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           ICURE_TEST_ADMIN_LOGIN: ${{ secrets.ICURE_TEST_ADMIN_LOGIN }}
           ICURE_TEST_ADMIN_PWD: ${{ secrets.ICURE_TEST_ADMIN_PWD }}

--- a/src/apis/AnonymousMedTechApi.ts
+++ b/src/apis/AnonymousMedTechApi.ts
@@ -123,11 +123,8 @@ export class AnonymousMedTechApiBuilder {
   }
 
   async build(): Promise<AnonymousMedTechApi> {
-    if (!this.authProcessByEmailId) {
-      throw new Error('authProcessIdByEmail is required')
-    }
-    if (!this.authProcessBySmsId) {
-      throw new Error('authProcessIdBySms is required')
+    if (!this.authProcessByEmailId && !this.authProcessBySmsId) {
+      throw new Error('At least one between authProcessIdBySms and authProcessByEmailId is required')
     }
     if (!this.msgGwSpecId) {
       throw new Error('msgGtwSpecId is required')

--- a/src/apis/AuthenticationApi.ts
+++ b/src/apis/AuthenticationApi.ts
@@ -48,7 +48,6 @@ export interface AuthenticationApi {
    * - In the case of a login, re-generate keys if needed (new keys different from previous ones);
    * @param process The AuthenticationProcess previously provided in the startAuthentication service
    * @param validationCode The validation code the user received by email/mobile phone
-   * @param getUserKeypair Lambda providing the user RSA Keypair. Get it from where you stored it previously or
    * generate a new one if user lost it (See AnonymousMedTechApi.generateRSAKeypair()).
    *
    * @return The result of the authentication and the related MedTechApi object corresponding to the newly authenticated
@@ -63,7 +62,6 @@ export interface AuthenticationApi {
    * - Send a Notification to all the delegated HCP to ask for access to the data of the Patient
    * @param userLogin The login of the user
    * @param shortLivedToken The short-lived authentication token created by the HCP
-   * @param getUserKeypair Lambda providing the user RSA Keypair. Get it from where you stored it previously or
    * generate a new one if user lost it (See AnonymousMedTechApi.generateRSAKeypair()).
    *
    * @return The result of the authentication and the related MedTechApi object corresponding to the newly authenticated

--- a/src/apis/MedTechApi.ts
+++ b/src/apis/MedTechApi.ts
@@ -232,7 +232,7 @@ export class MedTechApi {
   get authenticationApi(): AuthenticationApi {
     if (!this._authenticationApi) {
       throw Error(
-        "authenticationApi couldn't be initialized. Make sure you provided the following arguments : msgGwUrl, msgGwSpecId, authProcessByEmailId and authProcessBySMSId"
+        "authenticationApi couldn't be initialized. Make sure you provided the following arguments : msgGwUrl, msgGwSpecId, and at least one of authProcessByEmailId and authProcessBySMSId"
       )
     }
 

--- a/src/apis/impl/AuthenticationApiImpl.ts
+++ b/src/apis/impl/AuthenticationApiImpl.ts
@@ -70,15 +70,9 @@ export class AuthenticationApiImpl implements AuthenticationApi {
       )
     }
 
-    if(!!email && !this.authProcessByEmailId && (!phoneNumber || (!!phoneNumber && !this.authProcessBySmsId))) {
+    if(!!email && !this.authProcessByEmailId || (!!phoneNumber && !this.authProcessBySmsId))) {
       throw this.errorHandler.createErrorWithMessage(
-        `In order to start authentication of a user with an email, you need to instantiate the API with a authProcessByEmailId`
-      )
-    }
-
-    if(!!phoneNumber && !this.authProcessBySmsId && (!email || (!!email && !this.authProcessByEmailId))) {
-      throw this.errorHandler.createErrorWithMessage(
-        `In order to start authentication of a user with a phone number, you need to instantiate the API with a authProcessBySmsId`
+        `In order to start a user authentication with an email, you need to instantiate the API with a authProcessByEmailId. If you want to start the authenticcation with a  phone number, then you need to instantiate the API with a authProcessBySmsId`
       )
     }
 

--- a/src/apis/impl/AuthenticationApiImpl.ts
+++ b/src/apis/impl/AuthenticationApiImpl.ts
@@ -70,7 +70,19 @@ export class AuthenticationApiImpl implements AuthenticationApi {
       )
     }
 
-    const processId = email != undefined ? this.authProcessByEmailId : this.authProcessBySmsId
+    if(!!email && !this.authProcessByEmailId && (!phoneNumber || (!!phoneNumber && !this.authProcessBySmsId))) {
+      throw this.errorHandler.createErrorWithMessage(
+        `In order to start authentication of a user with an email, you need to instantiate the API with a authProcessByEmailId`
+      )
+    }
+
+    if(!!phoneNumber && !this.authProcessBySmsId && (!email || (!!email && !this.authProcessByEmailId))) {
+      throw this.errorHandler.createErrorWithMessage(
+        `In order to start authentication of a user with a phone number, you need to instantiate the API with a authProcessBySmsId`
+      )
+    }
+
+    const processId = (!!email && !!this.authProcessByEmailId) ? this.authProcessByEmailId : this.authProcessBySmsId
 
     const requestId = await this.messageGatewayApi.startProcess(
       processId,

--- a/src/apis/impl/AuthenticationApiImpl.ts
+++ b/src/apis/impl/AuthenticationApiImpl.ts
@@ -70,9 +70,9 @@ export class AuthenticationApiImpl implements AuthenticationApi {
       )
     }
 
-    if(!!email && !this.authProcessByEmailId || (!!phoneNumber && !this.authProcessBySmsId))) {
+    if((!!email && !this.authProcessByEmailId) || (!!phoneNumber && !this.authProcessBySmsId)) {
       throw this.errorHandler.createErrorWithMessage(
-        `In order to start a user authentication with an email, you need to instantiate the API with a authProcessByEmailId. If you want to start the authenticcation with a  phone number, then you need to instantiate the API with a authProcessBySmsId`
+        `In order to start a user authentication with an email, you need to instantiate the API with a authProcessByEmailId. If you want to start the authentication with a phone number, then you need to instantiate the API with a authProcessBySmsId`
       )
     }
 

--- a/test/apis/authentication-api.ts
+++ b/test/apis/authentication-api.ts
@@ -167,7 +167,7 @@ describe('Authentication API', () => {
       )
       expect(true, 'promise should fail').eq(false)
     } catch (e) {
-      expect((e as Error).message).to.eq('In order to start authentication of a user with an email, you need to instantiate the API with a authProcessByEmailId')
+      expect((e as Error).message).to.eq('In order to start a user authentication with an email, you need to instantiate the API with a authProcessByEmailId. If you want to start the authentication with a phone number, then you need to instantiate the API with a authProcessBySmsId')
     }
   })
 
@@ -194,7 +194,7 @@ describe('Authentication API', () => {
       )
       expect(true, 'promise should fail').eq(false)
     } catch (e) {
-      expect((e as Error).message).to.eq('In order to start authentication of a user with a phone number, you need to instantiate the API with a authProcessBySmsId')
+      expect((e as Error).message).to.eq('In order to start a user authentication with an email, you need to instantiate the API with a authProcessByEmailId. If you want to start the authentication with a phone number, then you need to instantiate the API with a authProcessBySmsId')
     }
   })
 

--- a/test/apis/authentication-api.ts
+++ b/test/apis/authentication-api.ts
@@ -74,7 +74,24 @@ describe('Authentication API', () => {
       expect(true, 'promise should fail').eq(false)
     } catch (e) {
       expect((e as Error).message).to.eq(
-        "authenticationApi couldn't be initialized. Make sure you provided the following arguments : msgGwUrl, msgGwSpecId, authProcessByEmailId and authProcessBySMSId"
+        "authenticationApi couldn't be initialized. Make sure you provided the following arguments : msgGwUrl, msgGwSpecId, and at least one of authProcessByEmailId and authProcessBySMSId"
+      )
+    }
+  }).timeout(60000)
+
+  it("Cannot instantiate the API if no AuthProcessId is passed", async () => {
+    // Given
+    try {
+      let api = await new AnonymousMedTechApiBuilder()
+        .withICureBaseUrl(env!.iCureUrl)
+        .withMsgGwUrl(env!.msgGtwUrl)
+        .withMsgGwSpecId(env!.specId)
+        .withCrypto(webcrypto as any)
+        .build()
+      expect(true, 'promise should fail').eq(false)
+    } catch (e) {
+      expect((e as Error).message).to.eq(
+        "At least one between authProcessIdBySms and authProcessByEmailId is required"
       )
     }
   }).timeout(60000)
@@ -126,6 +143,108 @@ describe('Authentication API', () => {
       expect((e as Error).message).to.eq('In order to start authentication of a user, you should at least provide its email OR its phone number')
     }
   })
+
+  it("User should not be able to start authentication if he provided an email but no AuthProcessByEmailId", async () => {
+    // Given
+    const anonymousMedTechApi = await new AnonymousMedTechApiBuilder()
+      .withICureBaseUrl(env!.iCureUrl)
+      .withMsgGwUrl(env!.msgGtwUrl)
+      .withMsgGwSpecId(env!.specId)
+      .withCrypto(webcrypto as any)
+      .withAuthProcessBySmsId(env!.hcpAuthProcessId)
+      .build()
+
+    // When
+    try {
+      await anonymousMedTechApi.authenticationApi.startAuthentication(
+        env!.recaptcha,
+        'a-fake-email',
+        undefined,
+        'Tom',
+        'Gideon',
+        env!.hcpAuthProcessId,
+        false
+      )
+      expect(true, 'promise should fail').eq(false)
+    } catch (e) {
+      expect((e as Error).message).to.eq('In order to start authentication of a user with an email, you need to instantiate the API with a authProcessByEmailId')
+    }
+  })
+
+  it("User should not be able to start authentication if he provided an sms but no AuthProcessBySMSId", async () => {
+    // Given
+    const anonymousMedTechApi = await new AnonymousMedTechApiBuilder()
+      .withICureBaseUrl(env!.iCureUrl)
+      .withMsgGwUrl(env!.msgGtwUrl)
+      .withMsgGwSpecId(env!.specId)
+      .withCrypto(webcrypto as any)
+      .withAuthProcessByEmailId(env!.hcpAuthProcessId)
+      .build()
+
+    // When
+    try {
+      await anonymousMedTechApi.authenticationApi.startAuthentication(
+        env!.recaptcha,
+        undefined,
+        'a-fake-phone-number',
+        'Tom',
+        'Gideon',
+        env!.hcpAuthProcessId,
+        false
+      )
+      expect(true, 'promise should fail').eq(false)
+    } catch (e) {
+      expect((e as Error).message).to.eq('In order to start authentication of a user with a phone number, you need to instantiate the API with a authProcessBySmsId')
+    }
+  })
+
+  it("A User should be able to start the authentication by sms", async () => {
+    // Given
+    const anonymousMedTechApi = await new AnonymousMedTechApiBuilder()
+      .withICureBaseUrl(env!.iCureUrl)
+      .withMsgGwUrl(env!.msgGtwUrl)
+      .withMsgGwSpecId(env!.specId)
+      .withCrypto(webcrypto as any)
+      .withAuthProcessBySmsId(env!.hcpAuthProcessId)
+      .build()
+
+    // When
+    const phoneNumber = `+${Math.ceil(Math.random()*10000000 + 10000000)}`
+    await anonymousMedTechApi.authenticationApi.startAuthentication(
+      env!.recaptcha,
+      undefined,
+      phoneNumber,
+      'Tom',
+      'Gideon',
+      env!.hcpAuthProcessId,
+      false
+    )
+    const messages = await TestUtils.getSMS(phoneNumber)
+    expect(messages?.message).not.to.be.undefined
+  })
+
+  it('HCP should be capable of signing up using email', async () => {
+    // When
+    const hcpApiAndUser = await TestUtils.signUpUserUsingEmail(
+      env!.iCureUrl,
+      env!.msgGtwUrl,
+      env!.specId,
+      env!.hcpAuthProcessId,
+      hcpId!,
+      env!.recaptcha,
+      'recaptcha'
+    )
+    const currentUser = hcpApiAndUser.user
+
+    // Then
+    assert(currentUser)
+    assert(currentUser.healthcarePartyId != null)
+
+    const currentHcp = await hcpApiAndUser.api.healthcareProfessionalApi.getHealthcareProfessional(currentUser.healthcarePartyId!)
+    assert(currentHcp)
+    assert(currentHcp.firstName == 'Antoine')
+    assert(currentHcp.lastName == 'Duchâteau')
+  }).timeout(60000)
 
   it('HCP should be capable of signing up using email', async () => {
     // When

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -221,6 +221,16 @@ export class TestUtils {
     return response
   }
 
+  static async getSMS(phoneNumber: string): Promise<any> {
+    const { msgGtwUrl, specId } = getEnvVariables()
+    const smsOptions = {
+      method: 'GET' as Method,
+      url: `${msgGtwUrl}/${specId}/lastSMS/${phoneNumber}`,
+    }
+    const { data: response } = await axios.request(smsOptions)
+    return response
+  }
+
   static async signUpUserUsingEmail(
     iCureUrl: string,
     msgGtwUrl: string,
@@ -249,7 +259,6 @@ export class TestUtils {
       .withMsgGwSpecId(msgGtwSpecId)
       .withCrypto(webcrypto as any)
       .withAuthProcessByEmailId(authProcessId)
-      .withAuthProcessBySmsId(authProcessId)
 
     if (storage) {
       builder.withStorage(storage)
@@ -260,7 +269,6 @@ export class TestUtils {
     }
 
     const anonymousMedTechApi = await builder.build()
-    const env = getEnvVariables()
 
     const email = getTempEmail()
     const process = await anonymousMedTechApi.authenticationApi.startAuthentication(


### PR DESCRIPTION
### Changes
When instantiating the MedTechAPI and the AnonymousMedTechApi is now possible to pass just one (but at least one) between `withAuthProcessByEmailId` and `withAuthProcessBySMSId`. Trying to authenticate a user by email without an `AuthProcessByEmailId` will result in an error, and the same is true for the SMS. 